### PR TITLE
Improved handling of app and bus information introducing dataclasses `AppInfo` and `BusInfo`

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -2,7 +2,7 @@
     "app": {
         "numgen": {
             "module": "apps.numgen",
-            "class": "NumGenApp",
+            "cls": "NumGenApp",
             "show": true,
             "pos": "left",
             "bus": ["dbbus"],
@@ -12,14 +12,14 @@
         },
         "dbmgr": {
             "module": "apps.dbmgr",
-            "class": "DBMgrApp",
+            "cls": "DBMgrApp",
             "show": true,
             "pos": "right",
             "bus": []
         },
         "datacalc": {
             "module": "apps.datacalc",
-            "class": "DataCalcApp",
+            "cls": "DataCalcApp",
             "show": true,
             "pos": "top",
             "bus": ["dbbus"],
@@ -32,7 +32,7 @@
         },
         "poller": {
             "module": "apps.poller",
-            "class": "PollerApp",
+            "cls": "PollerApp",
             "show": true,
             "pos": "bottom",
             "bus": ["dbbus"],
@@ -42,7 +42,7 @@
         },
         "logger": {
             "module": "apps.logger",
-            "class": "LoggerApp",
+            "cls": "LoggerApp",
             "show": true,
             "pos": "bottom",
             "bus": ["logbus"]

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -16,11 +16,40 @@ import json
 import importlib
 import importlib.util
 from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
 
 from PyQt5.QtCore import QObject, pyqtSlot, Qt
 from PyQt5.QtWidgets import QApplication, QMainWindow, QDockWidget
 
 from swift.bus import Bus
+
+@dataclass
+class AppInfo:
+    """Information required to create an app.
+    
+    Fields:
+        module: Module name in which the app class resides.
+        class_: App class name.
+        path: System path for module importing. None if it is not necessary.
+        show: Whether to show the app frames on creation.
+        pos: Position on the main window; refer to Qt.DockWidgetArea enum.
+          Should be one of "left", "right", "top", or "bottom", case-sensitive.
+          Otherwise, defaults to Qt.AllDockWidgetAreas.
+        bus: Buses which the app subscribes to.
+        args: Keyword argument dictionary of the app class constructor.
+          It must exclude name and parent arguments. Even if they exist, they will be ignored.
+          None for initializing the app with default values,
+          where only name and parent arguments will be passed.
+    """
+    module: str
+    class_: str
+    path: str | None = None
+    show: bool = True
+    pos: str = ""
+    bus: Iterable[str] = ()
+    args: Mapping[str, Any] | None = None
+
 
 class Swift(QObject):
     """Actual manager for swift system.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -17,7 +17,7 @@ import importlib
 import importlib.util
 from contextlib import contextmanager
 from dataclasses import dataclass, asdict
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Mapping, Self
 
 from PyQt5.QtCore import QObject, pyqtSlot, Qt
 from PyQt5.QtWidgets import QApplication, QMainWindow, QDockWidget
@@ -49,6 +49,30 @@ class AppInfo:
     pos: str = ""
     bus: Iterable[str] = ()
     args: Mapping[str, Any] | None = None
+
+    @classmethod
+    def parse(cls, info: str) -> Self:
+        """Constructs an AppInfo object from a JSON string.
+
+        This does not catch JSONDecodeErrors since it clearly requires the JSON string
+        for the input.
+        Care must be taken not to input a non-JSON formatted string.
+        
+        Args:
+            info: A JSON string of a dictionary that contains the information of an app.
+              Its keys are field names of AppInfo and values are corresponding values.
+              Exceptionally for "class_" field, "class" is also accepted.
+              If both "class_" and "class" exist, then "class" is ignored.
+              If both does not exist, a KeyError("class_") is raised.
+        
+        Raises:
+            KeyError: When there is no mandatory fields in info.
+        """
+        info: dict[str, Any] = json.loads(info)
+        class_ = info.pop("class", None)
+        if info.setdefault("class_", class_) is None:
+            raise KeyError("class_")
+        return cls(**info)
 
 
 @dataclass

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -83,7 +83,7 @@ class Swift(QObject):
         3. Create apps and show their frames.
     """
 
-    def __init__(self, setupEnv: dict, parent: QObject | None = None):
+    def __init__(self, setupEnv: Mapping[str, Mapping], parent: QObject | None = None):
         """
         Args:
             setupEnv: A dictionary containing set-up environment about app and bus.
@@ -103,7 +103,7 @@ class Swift(QObject):
         self.load(setupEnv["app"], setupEnv["bus"])
         self.mainWindow.show()
 
-    def load(self, appInfos: dict, busInfos: dict):
+    def load(self, appInfos: Mapping[str, Mapping], busInfos: Mapping[str, Mapping]):
         """Initializes swift system and loads the apps and buses.
         
         Args:
@@ -115,7 +115,7 @@ class Swift(QObject):
         for name, info in appInfos.items():
             self.createApp(name, info)
 
-    def createBus(self, name: str, info: dict):
+    def createBus(self, name: str, info: Mapping[str, Any]):
         """Creates a global bus using set-up environment.
         
         Args:
@@ -136,7 +136,7 @@ class Swift(QObject):
         self._buses[name] = bus
         self._subscribers.setdefault(name, set())
 
-    def createApp(self, name: str, info: dict):
+    def createApp(self, name: str, info: Mapping[str, Any]):
         """Creates an app and shows their frames using set-up environment.
         
         Args:

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -53,10 +53,6 @@ class AppInfo:
     @classmethod
     def parse(cls, info: str) -> Self:
         """Constructs an AppInfo object from a JSON string.
-
-        This does not catch JSONDecodeErrors since it clearly requires the JSON string
-        for the input.
-        Care must be taken not to input a non-JSON formatted string.
         
         Args:
             info: A JSON string of a dictionary that contains the information of an app.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -311,7 +311,7 @@ def _read_setup_file(setup_path: str) -> tuple[Mapping[str, AppInfo], Mapping[st
         setup_path: A path of set-up file.
 
     Returns:
-        (app_infos, bus_infos): Dictionaries of set-up information about app and bus.
+        A tuple of two dictionaries of set-up information about app and bus.
           See appInfos and busInfos in Swift.load() for more details.
     """
     with open(setup_path, encoding="utf-8") as setup_file:

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -287,29 +287,49 @@ def _get_argparser() -> argparse.ArgumentParser:
     return parser
 
 
-def _read_setup_file(setup_path: str) -> dict[str, dict]:
-    """Reads set-up information about app and bus from set-up file.
+def _read_setup_file(setup_path: str) -> tuple[Mapping[str, AppInfo], Mapping[str, BusInfo]]:
+    """Reads set-up information about app and bus from a JSON file.
 
+    The JSON file content should have the following structure:
+
+      {
+        "app": {
+          "app_name_0": {app_info_0},
+          ...
+        },
+        "bus": {
+          "bus_name_0": {bus_info_0},
+          ...
+        }
+      }
+
+    See AppInfo and its parse() for app_info_* structure.
+    See BusInfo and its parse() for bus_info_* structure.
+      
     Args:
         setup_path: A path of set-up file.
 
     Returns:
-        A dictionary containing set-up environment about app and bus.
-          For details, see Swift.__init__().
+        (app_infos, bus_infos): Dictionaries of set-up information about app and bus.
+          See appInfos and busInfos in Swift.load() for more details.
     """
     with open(setup_path, encoding="utf-8") as setup_file:
-        setup_data = json.load(setup_file)
-    return {key: setup_data[key] for key in ("app", "bus")}
+        setup_data: dict[str, dict] = json.load(setup_file)
+    app_dict = setup_data.get("app", {})
+    bus_dict = setup_data.get("bus", {})
+    app_infos = {name: AppInfo(**info) for (name, info) in app_dict.items()}
+    bus_infos = {name: BusInfo(**info) for (name, info) in bus_dict.items()}
+    return app_infos, bus_infos
 
 
 def main():
     """Main function that runs when swift module is executed rather than imported."""
     args = _get_argparser().parse_args()
     # read set-up information
-    setupEnv = _read_setup_file(args.setup_path)
+    app_infos, bus_infos = _read_setup_file(args.setup_path)
     # start GUI
     app = QApplication(sys.argv)
-    _swift = Swift(setupEnv)
+    _swift = Swift(app_infos, bus_infos)
     app.exec_()
 
 

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -143,7 +143,8 @@ class Swift(QObject):
         Args:
             appInfos: A dictionary whose keys are app names and the values are
               corresponding AppInfo objects. All the apps in the dictionary
-              will be created and shown if the show field is True.
+              will be created, and if the show field is True, its frames will
+              be shown.
             busInfos: A dictionary whose keys are bus names and the values are
               corresponding BusInfo objects. All the buses in the dictionary
               will be created and started.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -17,7 +17,7 @@ import importlib
 import importlib.util
 from contextlib import contextmanager
 from dataclasses import dataclass, asdict
-from typing import Any, Iterable, Mapping
+from typing import Dict, Tuple, Any, Iterable, Mapping
 
 from PyQt5.QtCore import QObject, pyqtSlot, Qt
 from PyQt5.QtWidgets import QApplication, QMainWindow, QDockWidget
@@ -64,7 +64,7 @@ class AppInfo:
         Raises:
             KeyError: When there is no mandatory fields in info.
         """
-        info: dict[str, Any] = json.loads(info)
+        info: Dict[str, Any] = json.loads(info)
         info_cls = info.pop("class", None)
         if info.setdefault("cls", info_cls) is None:
             raise KeyError("cls")
@@ -288,7 +288,7 @@ def _get_argparser() -> argparse.ArgumentParser:
     return parser
 
 
-def _read_setup_file(setup_path: str) -> tuple[Mapping[str, AppInfo], Mapping[str, BusInfo]]:
+def _read_setup_file(setup_path: str) -> Tuple[Mapping[str, AppInfo], Mapping[str, BusInfo]]:
     """Reads set-up information about app and bus from a JSON file.
 
     The JSON file content should have the following structure:
@@ -315,7 +315,7 @@ def _read_setup_file(setup_path: str) -> tuple[Mapping[str, AppInfo], Mapping[st
           See appInfos and busInfos in Swift.load() for more details.
     """
     with open(setup_path, encoding="utf-8") as setup_file:
-        setup_data: dict[str, dict] = json.load(setup_file)
+        setup_data: Dict[str, dict] = json.load(setup_file)
     app_dict = setup_data.get("app", {})
     bus_dict = setup_data.get("bus", {})
     app_infos = {name: AppInfo.parse(json.dumps(info)) for (name, info) in app_dict.items()}

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -31,7 +31,7 @@ class AppInfo:
     Fields:
         module: Module name in which the app class resides.
         class_: App class name.
-        path: System path for module importing. None if it is not necessary.
+        path: System path for module importing.
         show: Whether to show the app frames on creation.
         pos: Position on the main window; refer to Qt.DockWidgetArea enum.
           Should be one of "left", "right", "top", or "bottom", case-sensitive.
@@ -44,7 +44,7 @@ class AppInfo:
     """
     module: str
     class_: str
-    path: str | None = None
+    path: str = "."
     show: bool = True
     pos: str = ""
     bus: Iterable[str] = ()

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -52,7 +52,7 @@ class AppInfo:
 
     @classmethod
     def parse(cls, info: str) -> "AppInfo":
-        """Constructs an AppInfo object from a JSON string.
+        """Returns an AppInfo object from a JSON string.
         
         Args:
             info: A JSON string of a dictionary that contains the information of an app.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -80,6 +80,19 @@ class BusInfo:
     """
     timeout: float | None = None
 
+    @classmethod
+    def parse(cls, info: str) -> Self:
+        """Constructs a BusInfo object from a JSON string.
+        
+        Args:
+            info: A JSON string of a dictionary that contains the information of a bus.
+              Its keys are field names of BusInfo and values are corresponding values.
+        
+        Raises:
+            KeyError: When there is no mandatory fields in info.
+        """
+        return cls(**json.loads(info))
+
 
 def strinfo(info: AppInfo | BusInfo) -> str:
     """Returns a JSON string converted from the given info.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -83,7 +83,7 @@ class Swift(QObject):
         3. Create apps and show their frames.
     """
 
-    def __init__(self, setupEnv: dict, parent=None):
+    def __init__(self, setupEnv: dict, parent: QObject | None = None):
         """
         Args:
             setupEnv: A dictionary containing set-up environment about app and bus.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -160,15 +160,12 @@ class Swift(QObject):
             name: A name of the bus.
             info: A BusInfo object describing the bus.
         """
-        # create a bus
         if info.timeout is not None:
             bus = Bus(name, info.timeout)
         else:
             bus = Bus(name)
-        # set a slot of received signal to router
         bus.received.connect(self._routeToApp)
         bus.start()
-        # store the bus
         self._buses[name] = bus
         self._subscribers.setdefault(name, set())
 

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -317,8 +317,8 @@ def _read_setup_file(setup_path: str) -> tuple[Mapping[str, AppInfo], Mapping[st
         setup_data: dict[str, dict] = json.load(setup_file)
     app_dict = setup_data.get("app", {})
     bus_dict = setup_data.get("bus", {})
-    app_infos = {name: AppInfo(**info) for (name, info) in app_dict.items()}
-    bus_infos = {name: BusInfo(**info) for (name, info) in bus_dict.items()}
+    app_infos = {name: AppInfo.parse(json.dumps(info)) for (name, info) in app_dict.items()}
+    bus_infos = {name: BusInfo.parse(json.dumps(info)) for (name, info) in bus_dict.items()}
     return app_infos, bus_infos
 
 

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -51,6 +51,16 @@ class AppInfo:
     args: Mapping[str, Any] | None = None
 
 
+@dataclass
+class BusInfo:
+    """Information required to create a bus.
+    
+    Fields:
+        timeout: See bus.Bus.__init__(). None for the default value of __init__().
+    """
+    timeout: float | None = None
+
+
 class Swift(QObject):
     """Actual manager for swift system.
 

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -304,7 +304,7 @@ def _read_setup_file(setup_path: str) -> Tuple[Mapping[str, AppInfo], Mapping[st
           See appInfos and busInfos in Swift.load() for more details.
     """
     with open(setup_path, encoding="utf-8") as setup_file:
-        setup_data: Dict[str, dict] = json.load(setup_file)
+        setup_data: Dict[str, Dict[str, dict]] = json.load(setup_file)
     app_dict = setup_data.get("app", {})
     bus_dict = setup_data.get("bus", {})
     app_infos = {name: AppInfo(**info) for (name, info) in app_dict.items()}

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -116,16 +116,15 @@ class Swift(QObject):
         3. Create apps and show their frames.
     """
 
-    def __init__(self, setupEnv: Mapping[str, Mapping], parent: QObject | None = None):
+    def __init__(
+        self,
+        appInfos: Mapping[str, AppInfo] | None = None,
+        busInfos: Mapping[str, BusInfo] | None = None,
+        parent: QObject | None = None):
         """
         Args:
-            setupEnv: A dictionary containing set-up environment about app and bus.
-              It has two keys; "app" and "bus".
-              In "app", there are apps containing keys as below; 
-                "path" (optional), "module", "class", "show", "pos", "bus", and "args" (optional).
-              In "bus", there are buses containing keys as below;
-                "timeout" (optional).
-              For details, see setup.json.
+            appInfos: See Swift.load(). None or an empty dictionary for loading no apps.
+            busInfos: See Swift.load(). None or an empty dictionary for loading no buses.
             parent: A parent object.
         """
         super().__init__(parent=parent)
@@ -133,7 +132,9 @@ class Swift(QObject):
         self._buses = {}
         self._apps = {}
         self._subscribers = {}
-        self.load(setupEnv["app"], setupEnv["bus"])
+        appInfos = appInfos if appInfos else {}
+        busInfos = busInfos if busInfos else {}
+        self.load(appInfos, busInfos)
         self.mainWindow.show()
 
     def load(self, appInfos: Mapping[str, AppInfo], busInfos: Mapping[str, BusInfo]):

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -317,8 +317,8 @@ def _read_setup_file(setup_path: str) -> Tuple[Mapping[str, AppInfo], Mapping[st
         }
       }
 
-    See AppInfo and its parse() for app_info_* structure.
-    See BusInfo and its parse() for bus_info_* structure.
+    See AppInfo for app_info_* structure.
+    See BusInfo for bus_info_* structure.
       
     Args:
         setup_path: A path of set-up file.
@@ -331,8 +331,8 @@ def _read_setup_file(setup_path: str) -> Tuple[Mapping[str, AppInfo], Mapping[st
         setup_data: Dict[str, dict] = json.load(setup_file)
     app_dict = setup_data.get("app", {})
     bus_dict = setup_data.get("bus", {})
-    app_infos = {name: AppInfo.parse(json.dumps(info)) for (name, info) in app_dict.items()}
-    bus_infos = {name: BusInfo.parse(json.dumps(info)) for (name, info) in bus_dict.items()}
+    app_infos = {name: AppInfo(**info) for (name, info) in app_dict.items()}
+    bus_infos = {name: BusInfo(**info) for (name, info) in bus_dict.items()}
     return app_infos, bus_infos
 
 

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -328,9 +328,9 @@ def main():
     # read set-up information
     app_infos, bus_infos = _read_setup_file(args.setup_path)
     # start GUI
-    app = QApplication(sys.argv)
+    qapp = QApplication(sys.argv)
     _swift = Swift(app_infos, bus_infos)
-    app.exec_()
+    qapp.exec_()
 
 
 if __name__ == "__main__":

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -176,21 +176,16 @@ class Swift(QObject):
             name: A name of app.
             info: An AppInfo object describing the app.
         """
-        # import the app module
         with _add_to_path(os.path.dirname(info.path)):
             module = importlib.import_module(info.module)
-        # create an app
         cls = getattr(module, info.class_)
         if info.args is not None:
             app = cls(name, parent=self, **info.args)
         else:
             app = cls(name, parent=self)
-        # set a slot of broadcast signal to router
         app.broadcastRequested.connect(self._routeToBus)
-        # add the app to the list of subscribers on each bus
         for busName in info.bus:
             self._subscribers[busName].add(app)
-        # show frames if the "show" option is true
         if info.show:
             for frame in app.frames():
                 dockWidget = QDockWidget(name, self.mainWindow)
@@ -202,7 +197,6 @@ class Swift(QObject):
                     "bottom": Qt.BottomDockWidgetArea
                 }.get(info.pos, Qt.AllDockWidgetAreas)
                 self.mainWindow.addDockWidget(area, dockWidget)
-        # store the app
         self._apps[name] = app
 
     def destroyBus(self, name: str):

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -17,12 +17,18 @@ import importlib
 import importlib.util
 from contextlib import contextmanager
 from dataclasses import dataclass, asdict
-from typing import Dict, Tuple, Any, Iterable, Mapping, Optional, Union
+from typing import (
+    Dict, Tuple, Any, Iterable, Mapping, Optional, Union, TypeVar, Type
+)
 
 from PyQt5.QtCore import QObject, pyqtSlot, Qt
 from PyQt5.QtWidgets import QApplication, QMainWindow, QDockWidget
 
 from swift.bus import Bus
+
+
+T = TypeVar("T")
+
 
 @dataclass
 class AppInfo:
@@ -85,7 +91,7 @@ class BusInfo:
         return cls(**json.loads(info))
 
 
-def parse(cls, kwargs: str):
+def parse(cls: Type[T], kwargs: str) -> T:
     """Returns a new cls instance from a JSON string.
 
     This is a convenience function for just unpacking the JSON string and gives them

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -148,18 +148,16 @@ class Swift(QObject):
         for name, info in appInfos.items():
             self.createApp(name, info)
 
-    def createBus(self, name: str, info: Mapping[str, Any]):
-        """Creates a global bus using set-up environment.
+    def createBus(self, name: str, info: BusInfo):
+        """Creates a bus from the given information.
         
         Args:
             name: A name of the bus.
-            info: A dictionary containing bus info. Each element is like below:
-              timeout: Desired timeout for blocking queue reading, in seconds.
-                If you want to set as default, set None.
+            info: A BusInfo object describing the bus.
         """
         # create a bus
-        if "timeout" in info:
-            bus = Bus(name, info["timeout"])
+        if info.timeout is not None:
+            bus = Bus(name, info.timeout)
         else:
             bus = Bus(name)
         # set a slot of received signal to router

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -271,14 +271,14 @@ def _get_argparser() -> argparse.ArgumentParser:
     return parser
 
 
-def _read_setup_file(setup_path: str):
+def _read_setup_file(setup_path: str) -> dict[str, dict]:
     """Reads set-up information about app and bus from set-up file.
 
     Args:
         setup_path: A path of set-up file.
 
     Returns:
-        dict: A dictionary containing set-up environment about app and bus.
+        A dictionary containing set-up environment about app and bus.
           For details, see Swift.__init__().
     """
     with open(setup_path, encoding="utf-8") as setup_file:

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -253,13 +253,13 @@ def _add_to_path(path: str):
         sys.modules = old_modules
 
 
-def _get_argparser():
-    """Parses command line arguments
+def _get_argparser() -> argparse.ArgumentParser:
+    """Parses command line arguments.
 
     -s, --setup: A path of set-up file.
 
     Returns:
-        argparse.ArgumentParser: A namespace containing arguments
+        A namespace containing arguments.
     """
     parser = argparse.ArgumentParser(
         description="SNU widget integration framework for PyQt"

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -16,7 +16,7 @@ import json
 import importlib
 import importlib.util
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 from typing import Any, Iterable, Mapping
 
 from PyQt5.QtCore import QObject, pyqtSlot, Qt
@@ -59,6 +59,17 @@ class BusInfo:
         timeout: See bus.Bus.__init__(). None for the default value of __init__().
     """
     timeout: float | None = None
+
+
+def strinfo(info: AppInfo | BusInfo) -> str:
+    """Returns a JSON string converted from the given info.
+
+    This is just a convenience function for users not to import dataclasses and json.
+    
+    Args:
+        info: Dataclass object to convert to a JSON string.
+    """
+    return json.dumps(asdict(info))
 
 
 class Swift(QObject):

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -17,7 +17,7 @@ import importlib
 import importlib.util
 from contextlib import contextmanager
 from dataclasses import dataclass, asdict
-from typing import Dict, Tuple, Any, Iterable, Mapping
+from typing import Dict, Tuple, Any, Iterable, Mapping, Optional
 
 from PyQt5.QtCore import QObject, pyqtSlot, Qt
 from PyQt5.QtWidgets import QApplication, QMainWindow, QDockWidget
@@ -48,7 +48,7 @@ class AppInfo:
     show: bool = True
     pos: str = ""
     bus: Iterable[str] = ()
-    args: Mapping[str, Any] | None = None
+    args: Optional[Mapping[str, Any]] = None
 
     @classmethod
     def parse(cls, info: str) -> "AppInfo":
@@ -78,7 +78,7 @@ class BusInfo:
     Fields:
         timeout: See bus.Bus.__init__(). None for the default value of __init__().
     """
-    timeout: float | None = None
+    timeout: Optional[float] = None
 
     @classmethod
     def parse(cls, info: str) -> "BusInfo":
@@ -118,9 +118,9 @@ class Swift(QObject):
 
     def __init__(
         self,
-        appInfos: Mapping[str, AppInfo] | None = None,
-        busInfos: Mapping[str, BusInfo] | None = None,
-        parent: QObject | None = None):
+        appInfos: Optional[Mapping[str, AppInfo]] = None,
+        busInfos: Optional[Mapping[str, BusInfo]] = None,
+        parent: Optional[QObject] = None):
         """
         Args:
             appInfos: See Swift.load(). None or an empty dictionary for loading no apps.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -57,9 +57,8 @@ class AppInfo:
         Args:
             info: A JSON string of a dictionary that contains the information of an app.
               Its keys are field names of AppInfo and values are corresponding values.
-        
-        Raises:
-            KeyError: When there is no mandatory fields in info.
+              All the mandatory fields which does not have the default values must be given,
+              and any other fields that do not exist in AppInfo must not be given.
         """
         return cls(**json.loads(info))
 
@@ -80,9 +79,8 @@ class BusInfo:
         Args:
             info: A JSON string of a dictionary that contains the information of a bus.
               Its keys are field names of BusInfo and values are corresponding values.
-        
-        Raises:
-            KeyError: When there is no mandatory fields in info.
+              All the mandatory fields which does not have the default values must be given,
+              and any other fields that do not exist in BusInfo must not be given.
         """
         return cls(**json.loads(info))
 

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -17,7 +17,7 @@ import importlib
 import importlib.util
 from contextlib import contextmanager
 from dataclasses import dataclass, asdict
-from typing import Dict, Tuple, Any, Iterable, Mapping, Optional
+from typing import Dict, Tuple, Any, Iterable, Mapping, Optional, Union
 
 from PyQt5.QtCore import QObject, pyqtSlot, Qt
 from PyQt5.QtWidgets import QApplication, QMainWindow, QDockWidget
@@ -94,7 +94,7 @@ class BusInfo:
         return cls(**json.loads(info))
 
 
-def strinfo(info: AppInfo | BusInfo) -> str:
+def strinfo(info: Union[AppInfo, BusInfo]) -> str:
     """Returns a JSON string converted from the given info.
 
     This is just a convenience function for users not to import dataclasses and json.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -56,18 +56,6 @@ class AppInfo:
     bus: Iterable[str] = ()
     args: Optional[Mapping[str, Any]] = None
 
-    @classmethod
-    def parse(cls, info: str) -> "AppInfo":
-        """Returns an AppInfo object from a JSON string.
-        
-        Args:
-            info: A JSON string of a dictionary that contains the information of an app.
-              Its keys are field names of AppInfo and values are corresponding values.
-              All the mandatory fields which does not have the default values must be given,
-              and any other fields that do not exist in AppInfo must not be given.
-        """
-        return cls(**json.loads(info))
-
 
 @dataclass
 class BusInfo:
@@ -77,18 +65,6 @@ class BusInfo:
         timeout: See bus.Bus.__init__(). None for the default value of __init__().
     """
     timeout: Optional[float] = None
-
-    @classmethod
-    def parse(cls, info: str) -> "BusInfo":
-        """Constructs a BusInfo object from a JSON string.
-        
-        Args:
-            info: A JSON string of a dictionary that contains the information of a bus.
-              Its keys are field names of BusInfo and values are corresponding values.
-              All the mandatory fields which does not have the default values must be given,
-              and any other fields that do not exist in BusInfo must not be given.
-        """
-        return cls(**json.loads(info))
 
 
 def parse(cls: Type[T], kwargs: str) -> T:

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -30,7 +30,7 @@ class AppInfo:
     
     Fields:
         module: Module name in which the app class resides.
-        class_: App class name.
+        cls: App class name.
         path: System path for module importing.
         show: Whether to show the app frames on creation.
         pos: Position on the main window; refer to Qt.DockWidgetArea enum.
@@ -43,7 +43,7 @@ class AppInfo:
           where only name and parent arguments will be passed.
     """
     module: str
-    class_: str
+    cls: str
     path: str = "."
     show: bool = True
     pos: str = ""
@@ -57,17 +57,17 @@ class AppInfo:
         Args:
             info: A JSON string of a dictionary that contains the information of an app.
               Its keys are field names of AppInfo and values are corresponding values.
-              Exceptionally for "class_" field, "class" is also accepted.
-              If both "class_" and "class" exist, then "class" is ignored.
-              If both does not exist, a KeyError("class_") is raised.
+              Exceptionally for "cls" field, "class" is also accepted.
+              If both "cls" and "class" exist, then "class" is ignored.
+              If both does not exist, a KeyError("cls") is raised.
         
         Raises:
             KeyError: When there is no mandatory fields in info.
         """
         info: dict[str, Any] = json.loads(info)
-        class_ = info.pop("class", None)
-        if info.setdefault("class_", class_) is None:
-            raise KeyError("class_")
+        info_cls = info.pop("class", None)
+        if info.setdefault("cls", info_cls) is None:
+            raise KeyError("cls")
         return cls(**info)
 
 
@@ -178,7 +178,7 @@ class Swift(QObject):
         """
         with _add_to_path(os.path.dirname(info.path)):
             module = importlib.import_module(info.module)
-        cls = getattr(module, info.class_)
+        cls = getattr(module, info.cls)
         if info.args is not None:
             app = cls(name, parent=self, **info.args)
         else:

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -85,6 +85,22 @@ class BusInfo:
         return cls(**json.loads(info))
 
 
+def parse(cls, kwargs: str):
+    """Returns a new cls instance from a JSON string.
+
+    This is a convenience function for just unpacking the JSON string and gives them
+    as keyword arguments of the constructor of cls.
+        
+    Args:
+        cls: A class object.
+        kwargs: A JSON string of a dictionary that contains the keyword arguments of cls.
+            Positional arguments should be given with the argument names, just like
+            the other keyword arguments.
+            There must not exist arguments which are not in cls constructor.
+    """
+    return cls(**json.loads(kwargs))
+
+
 def strinfo(info: Union[AppInfo, BusInfo]) -> str:
     """Returns a JSON string converted from the given info.
 

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -136,12 +136,16 @@ class Swift(QObject):
         self.load(setupEnv["app"], setupEnv["bus"])
         self.mainWindow.show()
 
-    def load(self, appInfos: Mapping[str, Mapping], busInfos: Mapping[str, Mapping]):
+    def load(self, appInfos: Mapping[str, AppInfo], busInfos: Mapping[str, BusInfo]):
         """Initializes swift system and loads the apps and buses.
         
         Args:
-            appInfos: See "app" part of setupEnv in self.__init__().
-            busInfos: See "bus" part of setupEnv in self.__init__().
+            appInfos: A dictionary whose keys are app names and the values are
+              corresponding AppInfo objects. All the apps in the dictionary
+              will be created and shown if the show field is True.
+            busInfos: A dictionary whose keys are bus names and the values are
+              corresponding BusInfo objects. All the buses in the dictionary
+              will be created and started.
         """
         for name, info in busInfos.items():
             self.createBus(name, info)

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -17,7 +17,7 @@ import importlib
 import importlib.util
 from contextlib import contextmanager
 from dataclasses import dataclass, asdict
-from typing import Any, Iterable, Mapping, Self
+from typing import Any, Iterable, Mapping
 
 from PyQt5.QtCore import QObject, pyqtSlot, Qt
 from PyQt5.QtWidgets import QApplication, QMainWindow, QDockWidget
@@ -51,7 +51,7 @@ class AppInfo:
     args: Mapping[str, Any] | None = None
 
     @classmethod
-    def parse(cls, info: str) -> Self:
+    def parse(cls, info: str) -> "AppInfo":
         """Constructs an AppInfo object from a JSON string.
         
         Args:
@@ -81,7 +81,7 @@ class BusInfo:
     timeout: float | None = None
 
     @classmethod
-    def parse(cls, info: str) -> Self:
+    def parse(cls, info: str) -> "BusInfo":
         """Constructs a BusInfo object from a JSON string.
         
         Args:

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -57,18 +57,11 @@ class AppInfo:
         Args:
             info: A JSON string of a dictionary that contains the information of an app.
               Its keys are field names of AppInfo and values are corresponding values.
-              Exceptionally for "cls" field, "class" is also accepted.
-              If both "cls" and "class" exist, then "class" is ignored.
-              If both does not exist, a KeyError("cls") is raised.
         
         Raises:
             KeyError: When there is no mandatory fields in info.
         """
-        info: Dict[str, Any] = json.loads(info)
-        info_cls = info.pop("class", None)
-        if info.setdefault("cls", info_cls) is None:
-            raise KeyError("cls")
-        return cls(**info)
+        return cls(**json.loads(info))
 
 
 @dataclass

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -233,7 +233,7 @@ class Swift(QObject):
 
 
 @contextmanager
-def _add_to_path(path):
+def _add_to_path(path: str):
     """Adds a path temporarily.
 
     Using a 'with' statement, you can import a module without changing sys.path.


### PR DESCRIPTION
[`dataclasses.dataclass`](https://docs.python.org/3/library/dataclasses.html#dataclasses.dataclass) is useful when dealing with structured data with default values, etc.
I applied this to apps and buses initialization information in `swift`.
This makes things easier to check if the data has a proper structure.
Moreover, I implemented converter functions (`parse()` and `strinfo()`).

In addition, I removed some comments that seems merely repeating the codes.

Please freely give me your opinions!

Currently, pylint complains about type hints.
The main reason is that [`typing.Self`](https://docs.python.org/3/library/typing.html#typing.Self) is introduced in Python 3.11.
Also, the `|` in type hints is introduced in Python 3.10.
I will look for the workaround for this issue...

This closes #72 and closes #73.