### PR TITLE
Fix the error that the bus thread is not quited

### DIFF
--- a/swift/bus.py
+++ b/swift/bus.py
@@ -56,6 +56,7 @@ class Bus(QObject):
         self._thread.started.connect(self._consumer.run)
         self._thread.finished.connect(self._thread.deleteLater)
         self._consumer.finished.connect(self._thread.quit)
+        self._consumer.finished.connect(self._thread.wait)
         self._consumer.finished.connect(self._consumer.deleteLater)
         self._consumer.finished.connect(self._clean_up)
         self._consumer.consumed.connect(self.received)


### PR DESCRIPTION
So far, when the thread is finished, we only quit it.
However, the application is stopped so quickly, there is no enough time for bus thread to finish quit.
And it cause the error: `Destroyed while thread is still running`.

Thus, I just called [`wait()`](https://doc.qt.io/qt-5/qthread.html#wait) after [`quit()`](https://doc.qt.io/qt-5/qthread.html#quit).