### PR TITLE
`parent` parameter order to the last

### DIFF
--- a/examples/datacalc.py
+++ b/examples/datacalc.py
@@ -62,7 +62,7 @@ class DataCalcApp(BaseApp):
         Args:
             tables: See DataCalcApp.tables.
         """
-        super().__init__(name, parent)
+        super().__init__(name, parent=parent)
         self.tables = tables
         self.dbs = {"": ""}
         self.dbNames = {"A": "", "B": ""}

--- a/examples/dbmgr.py
+++ b/examples/dbmgr.py
@@ -94,7 +94,7 @@ class DBMgrApp(BaseApp):
 
     def __init__(self, name: str, parent: Optional[QObject] = None):
         """Extended."""
-        super().__init__(name, parent)
+        super().__init__(name, parent=parent)
         self.dbList = []
         self.managerFrame = ManagerFrame()
         # connect signals to slots

--- a/examples/numgen.py
+++ b/examples/numgen.py
@@ -69,7 +69,7 @@ class NumGenApp(BaseApp):
         generatorFrame: A frame that requests generating a random number.
         viewerFrame: A frame that shows the generated number.
     """
-    def __init__(self, name: str, parent: Optional[QObject] = None, table: str = "number"):
+    def __init__(self, name: str, table: str = "number", parent: Optional[QObject] = None):
         """Extended.
 
         Args:

--- a/examples/numgen.py
+++ b/examples/numgen.py
@@ -75,7 +75,7 @@ class NumGenApp(BaseApp):
         Args:
             table: A name of table to store the generated number.
         """
-        super().__init__(name, parent)
+        super().__init__(name, parent=parent)
         self.table = table
         self.dbs = {"": ""}
         self.dbName = ""

--- a/examples/poller.py
+++ b/examples/poller.py
@@ -62,7 +62,7 @@ class PollerApp(BaseApp):
         Args:
             table: See PollerApp.table.
         """
-        super().__init__(name, parent)
+        super().__init__(name, parent=parent)
         self.table = table
         self.dbs = {"": ""}
         self.dbName = ""

--- a/examples/poller.py
+++ b/examples/poller.py
@@ -56,7 +56,7 @@ class PollerApp(BaseApp):
         count: The polled count. It starts from 0.
         timer: A QTimer object for polling. The initial interval is a second.
     """
-    def __init__(self, name: str, parent: Optional[QObject] = None, table: str = "B"):
+    def __init__(self, name: str, table: str = "B", parent: Optional[QObject] = None):
         """Extended.
 
         Args:

--- a/swift/bus.py
+++ b/swift/bus.py
@@ -3,6 +3,7 @@ Module for bus features.
 """
 
 from queue import Queue, SimpleQueue, Empty
+from typing import Optional
 
 from PyQt5.QtCore import QObject, QThread, pyqtSignal, pyqtSlot
 
@@ -20,13 +21,14 @@ class Bus(QObject):
 
     received = pyqtSignal(str)
 
-    def __init__(self, name: str, timeout: float = 1):
+    def __init__(self, name: str, timeout: float = 1, parent: Optional[QObject] = None):
         """
         Args:
             name: Name of the bus for identification.
             timeout: See QueueConsumer.__init__().
+            parent: Parent object.
         """
-        super().__init__()
+        super().__init__(parent=parent)
         self.name = name
         self._queue = SimpleQueue()  # message queue
         self._timeout = timeout
@@ -94,14 +96,15 @@ class QueueConsumer(QObject):
     consumed = pyqtSignal(str)
     finished = pyqtSignal()
 
-    def __init__(self, queue_: Queue, timeout: float = 1):
+    def __init__(self, queue_: Queue, timeout: float = 1, parent: Optional[QObject] = None):
         """
         Args:
             queue_: A queue.Queue-like object which implements get() and Empty.
             timeout: Desired timeout for blocking queue reading, in seconds.
               This should not be None in order not to become uniterruptible.
+            parent: Parent object.
         """
-        super().__init__()
+        super().__init__(parent=parent)
         self._queue = queue_
         self._timeout = timeout
         self._running = True


### PR DESCRIPTION
I moved the `parent` parameter to the last parameter of constructors.
Moreover, `Bus` and `QueueConsumer` didn't have the `parent`, so I added it.
In addition, I changed to only using keyword argument passing for `parent`, i.e., `__init__(arg1, ..., parent=parent)`.

This closes #98.