### PR TITLE
Implment system request protocol

### DIFF
--- a/swift/app.py
+++ b/swift/app.py
@@ -21,6 +21,7 @@ class BaseApp(QObject):
 
     broadcastRequested = pyqtSignal(str, str)
     received = pyqtSignal(str, str)
+    swiftcallRequested = pyqtSignal(str)
 
     def __init__(self, name: str, parent: Optional[QObject] = None):
         """

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -214,20 +214,20 @@ class Swift(QObject):
             print(f"swift.swift._callSwift(): {e!r}")
             return
         if any(key not in msg for key in ("action", "args")):
-            print(f"The message was ignored because "
-                  f"it has no such key; action or args.")
+            print("The message was ignored because "
+                  "it has no such key; action or args.")
             return
         action, args = msg["action"], msg["args"]
         if action == "create":
             if any(key not in args for key in ("name", "info")):
-                print(f"The message was ignored because "
-                      f"args of the create action have no such key; name or info.")
+                print("The message was ignored because "
+                      "args of the create action have no such key; name or info.")
                 return
             self.createApp(args["name"], AppInfo(**args["info"]))
         elif action == "destroy":
             if any(key not in args for key in ("name",)):
-                print(f"The message was ignored because "
-                      f"args of the destroy action have no such key; name.")
+                print("The message was ignored because "
+                      "args of the destroy action have no such key; name.")
                 return
             self.destroyApp(args["name"])
         else:

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -90,7 +90,7 @@ class Swift(QObject):
 
     A swift-call is a request for the swift system such as creating an app.
     Messages emitted from "swiftcallRequested" signal are considered as swift-call.
-    For details, see _callSwift().
+    For details, see _swiftcall().
 
     Brief procedure:
         1. Load setup environment.
@@ -146,7 +146,7 @@ class Swift(QObject):
         else:
             app = cls(name, parent=self)
         app.broadcastRequested.connect(self._broadcast, type=Qt.QueuedConnection)
-        app.swiftcallRequested.connect(self._callSwift, type=Qt.QueuedConnection)
+        app.swiftcallRequested.connect(self._swiftcall, type=Qt.QueuedConnection)
         for channelName in info.channel:
             self._subscribers[channelName].add(app)
         for frame in app.frames():
@@ -190,7 +190,7 @@ class Swift(QObject):
             app.received.emit(channelName, msg)
 
     @pyqtSlot(str)
-    def _callSwift(self, msg: str):
+    def _swiftcall(self, msg: str):
         """Handles the swift-call.
 
         Args:
@@ -208,7 +208,7 @@ class Swift(QObject):
         try:
             msg = json.loads(msg)
         except json.JSONDecodeError as e:
-            print(f"swift.swift._callSwift(): {e!r}")
+            print(f"swift.swift._swiftcall(): {e!r}")
             return
         if any(key not in msg for key in ("action", "args")):
             print("The message was ignored because "

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -187,12 +187,28 @@ class Swift(QObject):
             app.received.emit(channelName, msg)
 
     def _call_system(self, msg: str):
+        """Handles the system call.
+
+        Args:
+            msg: A JSON string of a message about a system call.
+              Its keys represent an action. 
+              All requested actions are performed sequentially.
+              Possible actions are as follows.
+              
+              "create": create an app.
+                its value is a name of app you want to create.
+              "destroy": destroy an app.
+                its value is a dictionary with two keys; "name" and "info".
+                The value of "name" is a name of app you want to destroy.
+                The value of "info" is a JSON string of a dictionary 
+                  that contains the keyword arguments of AppInfo.
+        """
         msg = json.loads(msg)
         for action, contents in msg.items():
-            if action == "destroy":
-                self.destroyApp(contents)
-            elif action == "create":
+            if action == "create":
                 self.createApp(contents["name"], AppInfo(**contents["info"]))
+            elif action == "destroy":
+                self.destroyApp(contents)
             else:
                 print(f"The system call was ignored because "
                       f"the treatment for the action {action} is not implemented.")

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -195,20 +195,22 @@ class Swift(QObject):
               All requested actions are performed sequentially.
               Possible actions are as follows.
               
-              "create": create an app.
-                its value is a name of app you want to create.
-              "destroy": destroy an app.
-                its value is a dictionary with two keys; "name" and "info".
-                The value of "name" is a name of app you want to destroy.
+              "create": Create an app.
+                Its value is a list of dictionaries with two keys; "name" and "info".
+                The value of "name" is a name of app you want to create.
                 The value of "info" is a JSON string of a dictionary 
                   that contains the keyword arguments of AppInfo.
+              "destory": Destroy an app.
+                Its value is a list of names of app you want to destroy.
         """
         msg = json.loads(msg)
         for action, contents in msg.items():
             if action == "create":
-                self.createApp(contents["name"], AppInfo(**contents["info"]))
+                for app in contents:
+                    self.createApp(app["name"], AppInfo(**app["info"]))
             elif action == "destroy":
-                self.destroyApp(contents)
+                for name in contents:
+                    self.destroyApp(name)
             else:
                 print(f"The system call was ignored because "
                       f"the treatment for the action {action} is not implemented.")

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -88,6 +88,10 @@ class Swift(QObject):
 
     Note that QApplication instance must be created before instantiating Swift object.
 
+    A swift-call is a request for the swift system such as creating an app.
+    Messages trasferred through "swift" channel are considered as swift-call.
+    For details, see _callSwift().
+
     Brief procedure:
         1. Load setup environment.
         2. Create apps and show their frames.
@@ -177,22 +181,22 @@ class Swift(QObject):
     def _broadcast(self, channelName: str, msg: str):
         """Broadcasts the message to the subscriber apps of the channel.
 
-        If channelName is "swift", the message is for system call.
+        If channelName is "swift", the message is for swift-call.
 
         Args:
             channelName: Target channel name.
             msg: Message to be broadcast.
         """
         if channelName == "swift":
-            self._call_system(msg)
+            self._callSwift(msg)
         for app in self._subscribers[channelName]:
             app.received.emit(channelName, msg)
 
-    def _call_system(self, msg: str):
-        """Handles the system call.
+    def _callSwift(self, msg: str):
+        """Handles the swift-call.
 
         Args:
-            msg: A JSON string of a message about a system call.
+            msg: A JSON string of a message about a swift-call.
               Its keys represent an action. 
               All requested actions are performed sequentially.
               Possible actions are as follows.
@@ -214,7 +218,7 @@ class Swift(QObject):
                 for name in contents:
                     self.destroyApp(name)
             else:
-                print(f"The system call was ignored because "
+                print(f"The swift-call was ignored because "
                       f"the treatment for the action {action} is not implemented.")
 
 

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -171,12 +171,19 @@ class Swift(QObject):
     def _broadcast(self, channelName: str, msg: str):
         """Broadcasts the message to the subscriber apps of the channel.
 
+        If channelName is "swift", the message is for system call.
+
         Args:
             channelName: Target channel name.
             msg: Message to be broadcast.
         """
+        if channelName == "swift":
+            self._call_system(msg)
         for app in self._subscribers[channelName]:
             app.received.emit(channelName, msg)
+
+    def _call_system(self, msg: str):
+        print(msg)
 
 
 @contextmanager

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -191,6 +191,8 @@ class Swift(QObject):
         for action, contents in msg.items():
             if action == "destroy":
                 self.destroyApp(contents)
+            elif action == "create":
+                self.createApp(contents["name"], AppInfo(**contents["info"]))
 
 
 @contextmanager

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -186,8 +186,6 @@ class Swift(QObject):
             channelName: Target channel name.
             msg: Message to be broadcast.
         """
-        if channelName == "swift":
-            self._callSwift(msg)
         for app in self._subscribers[channelName]:
             app.received.emit(channelName, msg)
 

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -193,6 +193,9 @@ class Swift(QObject):
                 self.destroyApp(contents)
             elif action == "create":
                 self.createApp(contents["name"], AppInfo(**contents["info"]))
+            else:
+                print(f"The system call was ignored because "
+                      f"the treatment for the action {action} is not implemented.")
 
 
 @contextmanager

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -195,13 +195,12 @@ class Swift(QObject):
 
         Args:
             msg: A JSON string of a message with two keys; "action" and "args".
-              A possible action is as follows.
+              Possible actions are as follows.
               
               "create": Create an app.
                 Its "args" is a dictionary with two keys; "name" and "info".
                 The value of "name" is a name of app you want to create.
-                The value of "info" is a JSON string of a dictionary 
-                  that contains the keyword arguments of AppInfo.
+                The value of "info" is a dictionary that contains the keyword arguments of AppInfo.
               "destory": Destroy an app.
                 Its "args" is a dictionary with a key; "name".
                 The value of "name" is a name of app you want to destroy.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -89,7 +89,7 @@ class Swift(QObject):
     Note that QApplication instance must be created before instantiating Swift object.
 
     A swift-call is a request for the swift system such as creating an app.
-    Messages trasferred through "swift" channel are considered as swift-call.
+    Messages emitted from "swiftcallRequested" signal are considered as swift-call.
     For details, see _callSwift().
 
     Brief procedure:

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -146,6 +146,7 @@ class Swift(QObject):
         else:
             app = cls(name, parent=self)
         app.broadcastRequested.connect(self._broadcast, type=Qt.QueuedConnection)
+        app.swiftcallRequested.connect(self._callSwift, type=Qt.QueuedConnection)
         for channelName in info.channel:
             self._subscribers[channelName].add(app)
         for frame in app.frames():
@@ -181,8 +182,6 @@ class Swift(QObject):
     def _broadcast(self, channelName: str, msg: str):
         """Broadcasts the message to the subscriber apps of the channel.
 
-        If channelName is "swift", the message is for swift-call.
-
         Args:
             channelName: Target channel name.
             msg: Message to be broadcast.
@@ -192,6 +191,7 @@ class Swift(QObject):
         for app in self._subscribers[channelName]:
             app.received.emit(channelName, msg)
 
+    @pyqtSlot(str)
     def _callSwift(self, msg: str):
         """Handles the swift-call.
 


### PR DESCRIPTION
This PR will close #119.

I implemented the system request protocol as follows.
- When an app emits `broadcastRequested` signal with channel name `swift`, `_broadcase()` in swift handles it as a system call.
- The message is a JSON string with action keys. Possible actions are as follows.
  - "create": Create an app.
    - Its value is a list of dictionaries with two keys; "name" and "info".
    - The value of "name" is a name of app you want to create.
    - The value of "info" is a JSON string of a dictionary that contains the keyword arguments of AppInfo.
  - "destory": Destroy an app.
    - Its value is a list of names of app you want to destroy.

### Test
For test, I implemented the test branch, `BECATRUE/119/swift-call-test`.

In the test, when the generator button in `numgen` clicked, it emits a system request to destroy `logger` and create `poller`.
```python
msg = {
    "destroy": ["logger"],
    "create": [{
        "name": "poller",
        "info": {
            "module": "examples.poller",
            "cls": "PollerApp",
            "show": True,
            "pos": "bottom",
            "channel": ["db"],
            "args": {
                "table": "B"
            }
        }
    }]
}
self.broadcastRequested.emit("swift", json.dumps(msg))
```

#### Before clicked
<img width="60%" alt="img" src="https://user-images.githubusercontent.com/76851886/229453691-71825bdb-fdc3-4ea5-ace3-eb5388973977.png">

#### After clicked
<img width="60%" alt="img" src="https://user-images.githubusercontent.com/76851886/229453863-b684a475-5e74-4d17-a2c4-b87524abe037.png">
