### PR TITLE
Becatrue/132/swift call window

### DIFF
--- a/swift/swift.py
+++ b/swift/swift.py
@@ -223,7 +223,7 @@ class Swift(QObject):
             name, info = args["name"], args["info"]
             reply = QMessageBox.warning(
                 None, 
-                "Swift-call",
+                "swift-call",
                 f"The app {self.sender().name} requests for creating an app {name}",
                 QMessageBox.Ok | QMessageBox.Cancel,
                 QMessageBox.Cancel
@@ -238,7 +238,7 @@ class Swift(QObject):
             name = args["name"]
             reply = QMessageBox.warning(
                 None, 
-                "Swift-call",
+                "swift-call",
                 f"The app {self.sender().name} requests for destroying an app {name}",
                 QMessageBox.Ok | QMessageBox.Cancel,
                 QMessageBox.Cancel

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -235,7 +235,16 @@ class Swift(QObject):
                 print("The message was ignored because "
                       "args of the destroy action have no such key; name.")
                 return
-            self.destroyApp(args["name"])
+            name = args["name"]
+            reply = QMessageBox.warning(
+                None, 
+                "Swift-call",
+                f"The app {self.sender().name} requests for destroying an app {name}",
+                QMessageBox.Ok | QMessageBox.Cancel,
+                QMessageBox.Cancel
+            )
+            if reply == QMessageBox.Ok:
+                self.destroyApp(name)
         else:
             print(f"The swift-call was ignored because "
                   f"the treatment for the action {action} is not implemented.")

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -222,7 +222,7 @@ class Swift(QObject):
                 return
             name, info = args["name"], args["info"]
             reply = QMessageBox.warning(
-                None, 
+                None,
                 "swift-call",
                 f"The app {self.sender().name} requests for creating an app {name}",
                 QMessageBox.Ok | QMessageBox.Cancel,
@@ -237,7 +237,7 @@ class Swift(QObject):
                 return
             name = args["name"]
             reply = QMessageBox.warning(
-                None, 
+                None,
                 "swift-call",
                 f"The app {self.sender().name} requests for destroying an app {name}",
                 QMessageBox.Ok | QMessageBox.Cancel,

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -23,7 +23,7 @@ from typing import (
 )
 
 from PyQt5.QtCore import QObject, pyqtSlot, Qt
-from PyQt5.QtWidgets import QApplication, QMainWindow, QLabel, QDockWidget
+from PyQt5.QtWidgets import QApplication, QMainWindow, QLabel, QDockWidget, QMessageBox
 
 
 T = TypeVar("T")
@@ -220,7 +220,16 @@ class Swift(QObject):
                 print("The message was ignored because "
                       "args of the create action have no such key; name or info.")
                 return
-            self.createApp(args["name"], AppInfo(**args["info"]))
+            name, info = args["name"], args["info"]
+            reply = QMessageBox.warning(
+                None, 
+                "Swift-call",
+                f"The app {self.sender().name} requests for creating an app {name}",
+                QMessageBox.Ok | QMessageBox.Cancel,
+                QMessageBox.Cancel
+            )
+            if reply == QMessageBox.Ok:
+                self.createApp(name, AppInfo(**info))
         elif action == "destroy":
             if any(key not in args for key in ("name",)):
                 print("The message was ignored because "


### PR DESCRIPTION
This PR will close #132.

I implmented a window to allow `swift-call` requests.
When the `swift` receives a `swift-call` request, it opens a window which contains two buttons; "Ok" and "Cancel".
If you click "OK" button, the request will be operated, and if you click "Cancel" button or close the window, it will be rejected.

The example implementation can be checked in `BECATRUE/132/swift-call-window-test` branch.