### PR TITLE
Swift-call result interface

### DIFF
--- a/swift/app.py
+++ b/swift/app.py
@@ -18,6 +18,8 @@ class BaseApp(QObject):
           which contains the target channel name and the message.
         received(str, str): A signal for receiving a global signal from a channel
           which contains the source channel name and the message.
+        TODO(kangz12345): docstring for swiftcallRequested and swiftcallReturned.
+          They should be written when the swiftcall protocol is finally determined.
     """
 
     broadcastRequested = pyqtSignal(str, str)

--- a/swift/app.py
+++ b/swift/app.py
@@ -25,7 +25,7 @@ class BaseApp(QObject):
     broadcastRequested = pyqtSignal(str, str)
     received = pyqtSignal(str, str)
     swiftcallRequested = pyqtSignal(str)
-    swiftcallReturned = pyqtSignal(str)
+    swiftcallReturned = pyqtSignal(str, str)
 
     def __init__(self, name: str, parent: Optional[QObject] = None):
         """

--- a/swift/app.py
+++ b/swift/app.py
@@ -23,6 +23,7 @@ class BaseApp(QObject):
     broadcastRequested = pyqtSignal(str, str)
     received = pyqtSignal(str, str)
     swiftcallRequested = pyqtSignal(str)
+    swiftcallReturned = pyqtSignal(str)
 
     def __init__(self, name: str, parent: Optional[QObject] = None):
         """

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -270,7 +270,7 @@ class Swift(QObject):
         sender = self.sender()
         try:
             value = self._handleSwiftcall(sender.name, msg)
-        except Exception as error:
+        except Exception as error: # pylint: disable=broad-exception-caught
             result = Result(done=True, success=False, error=repr(error))
         else:
             result = Result(done=True, success=True, value=value)

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -247,7 +247,7 @@ class Swift(QObject):
             )
             if reply == QMessageBox.Ok:
                 return self.createApp(name, AppInfo(**info))
-            raise RuntimeError("user rejected the request.")
+            raise RuntimeError("The user rejected the request.")
         if action == "destroy":
             name = args["name"]
             reply = QMessageBox.warning(
@@ -259,7 +259,7 @@ class Swift(QObject):
             )
             if reply == QMessageBox.Ok:
                 return self.destroyApp(name)
-            raise RuntimeError("user rejected the request.")
+            raise RuntimeError("The user rejected the request.")
         raise NotImplementedError(action)
 
     def _swiftcall(self, sender: str, msg: str):

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -223,6 +223,10 @@ class Swift(QObject):
               "destory": Destroy an app.
                 Its "args" is a dictionary with a key; "name".
                 The value of "name" is a name of app you want to destroy.
+        
+        Raises:
+            RuntimeError: When the user rejects the request.
+            NotImplementedError: When the given request action is not implemented.
         """
         msg = json.loads(msg)
         action, args = msg["action"], msg["args"]
@@ -237,6 +241,8 @@ class Swift(QObject):
             )
             if reply == QMessageBox.Ok:
                 self.createApp(name, AppInfo(**info))
+            else:
+                raise RuntimeError("user rejected the request.")
         elif action == "destroy":
             name = args["name"]
             reply = QMessageBox.warning(
@@ -248,9 +254,10 @@ class Swift(QObject):
             )
             if reply == QMessageBox.Ok:
                 self.destroyApp(name)
+            else:
+                raise RuntimeError("user rejected the request.")
         else:
-            print(f"The swift-call was ignored because "
-                  f"the treatment for the action {action} is not implemented.")
+            raise NotImplementedError(action)
 
 
 @contextmanager

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -274,7 +274,7 @@ class Swift(QObject):
         """
         try:
             value = self._handleSwiftcall(sender, msg)
-        except Exception as error: # pylint: disable=broad-exception-caught
+        except Exception as error:  # pylint: disable=broad-exception-caught
             result = Result(done=True, success=False, error=repr(error))
         else:
             result = Result(done=True, success=True, value=value)

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -83,6 +83,22 @@ def strinfo(info: AppInfo) -> str:
     return json.dumps(asdict(info))
 
 
+@dataclass
+class Result:
+    """Result data of a swift-call.
+    
+    Fields:
+        done: Whether the swift-call is done. True when the it has failed as well.
+        success: True when the swift-call is done without any problems.
+        value: Return value of the swift-call, if any. It must be converted to a JSON string.
+        error: Information about the problem that occurred during the swift-call.
+    """
+    done: bool
+    success: bool
+    value: Any
+    error: Optional[str]
+
+
 class Swift(QObject):
     """Actual manager for swift system.
 

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -209,6 +209,9 @@ class Swift(QObject):
     def _swiftcall(self, msg: str):
         """Handles the swift-call.
 
+        This can raise an exception if the arguments do not follow the valid API.
+        The caller must obey the API and catch the possible exceptions.
+
         Args:
             msg: A JSON string of a message with two keys; "action" and "args".
               Possible actions are as follows.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -205,13 +205,14 @@ class Swift(QObject):
         for app in self._subscribers[channelName]:
             app.received.emit(channelName, msg)
 
-    def _handleSwiftcall(self, msg: str) -> Any:
+    def _handleSwiftcall(self, sender: str, msg: str) -> Any:
         """Handles the swift-call.
 
         This can raise an exception if the arguments do not follow the valid API.
         The caller must obey the API and catch the possible exceptions.
 
         Args:
+            sender: The name of the request sender app.
             msg: A JSON string of a message with two keys; "action" and "args".
               Possible actions are as follows.
               
@@ -237,7 +238,7 @@ class Swift(QObject):
             reply = QMessageBox.warning(
                 None,
                 "swift-call",
-                f"The app {self.sender().name} requests for creating an app {name}",
+                f"The app {sender} requests for creating an app {name}",
                 QMessageBox.Ok | QMessageBox.Cancel,
                 QMessageBox.Cancel
             )
@@ -250,7 +251,7 @@ class Swift(QObject):
             reply = QMessageBox.warning(
                 None,
                 "swift-call",
-                f"The app {self.sender().name} requests for destroying an app {name}",
+                f"The app {sender} requests for destroying an app {name}",
                 QMessageBox.Ok | QMessageBox.Cancel,
                 QMessageBox.Cancel
             )
@@ -270,7 +271,7 @@ class Swift(QObject):
         """
         sender = self.sender()
         try:
-            value = self._handleSwiftcall(msg)
+            value = self._handleSwiftcall(sender.name, msg)
         except Exception as error:
             result = Result(done=True, success=False, error=repr(error))
         else:

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -261,6 +261,22 @@ class Swift(QObject):
         else:
             raise NotImplementedError(action)
 
+    @pyqtSlot(str)
+    def _swiftcall(self, msg: str):
+        """Slot for the swiftcallRequested signal.
+
+        Args:
+            msg: See _handleSwiftcall().
+        """
+        sender = self.sender()
+        try:
+            value = self._handleSwiftcall(msg)
+        except Exception as error:
+            result = Result(done=True, success=False, error=repr(error))
+        else:
+            result = Result(done=True, success=True, value=value)
+        sender.swiftcallReturned.emit(msg, json.dumps(dataclasses.asdict(result)))
+
 
 @contextmanager
 def _add_to_path(path: str):

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -221,21 +221,9 @@ class Swift(QObject):
                 Its "args" is a dictionary with a key; "name".
                 The value of "name" is a name of app you want to destroy.
         """
-        try:
-            msg = json.loads(msg)
-        except json.JSONDecodeError as e:
-            print(f"swift.swift._swiftcall(): {e!r}")
-            return
-        if any(key not in msg for key in ("action", "args")):
-            print("The message was ignored because "
-                  "it has no such key; action or args.")
-            return
+        msg = json.loads(msg)
         action, args = msg["action"], msg["args"]
         if action == "create":
-            if any(key not in args for key in ("name", "info")):
-                print("The message was ignored because "
-                      "args of the create action have no such key; name or info.")
-                return
             name, info = args["name"], args["info"]
             reply = QMessageBox.warning(
                 None,
@@ -247,10 +235,6 @@ class Swift(QObject):
             if reply == QMessageBox.Ok:
                 self.createApp(name, AppInfo(**info))
         elif action == "destroy":
-            if any(key not in args for key in ("name",)):
-                print("The message was ignored because "
-                      "args of the destroy action have no such key; name.")
-                return
             name = args["name"]
             reply = QMessageBox.warning(
                 None,

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -84,6 +84,20 @@ def strinfo(info: AppInfo) -> str:
 
 
 @dataclasses.dataclass
+class SwiftcallInfo:
+    """Information specifying a swiftcall.
+    
+    Fields:
+        call: Swiftcall method name, e.g., "createApp". It should be a valid
+          public method name of a Swift instance.
+        args: Arguments for the call, all as keyword arguments. The arguments
+          should follow the public API as well.
+    """
+    call: str
+    args: Mapping[str, Any] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass
 class Result:
     """Result data of a swift-call.
     

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -244,8 +244,7 @@ class Swift(QObject):
             )
             if reply == QMessageBox.Ok:
                 return self.createApp(name, AppInfo(**info))
-            else:
-                raise RuntimeError("user rejected the request.")
+            raise RuntimeError("user rejected the request.")
         elif action == "destroy":
             name = args["name"]
             reply = QMessageBox.warning(
@@ -257,8 +256,7 @@ class Swift(QObject):
             )
             if reply == QMessageBox.Ok:
                 return self.destroyApp(name)
-            else:
-                raise RuntimeError("user rejected the request.")
+            raise RuntimeError("user rejected the request.")
         else:
             raise NotImplementedError(action)
 

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -227,6 +227,9 @@ class Swift(QObject):
         Raises:
             RuntimeError: When the user rejects the request.
             NotImplementedError: When the given request action is not implemented.
+        
+        Returns:
+            The returned value of the swift-call, if any.
         """
         msg = json.loads(msg)
         action, args = msg["action"], msg["args"]
@@ -240,7 +243,7 @@ class Swift(QObject):
                 QMessageBox.Cancel
             )
             if reply == QMessageBox.Ok:
-                self.createApp(name, AppInfo(**info))
+                return self.createApp(name, AppInfo(**info))
             else:
                 raise RuntimeError("user rejected the request.")
         elif action == "destroy":
@@ -253,7 +256,7 @@ class Swift(QObject):
                 QMessageBox.Cancel
             )
             if reply == QMessageBox.Ok:
-                self.destroyApp(name)
+                return self.destroyApp(name)
             else:
                 raise RuntimeError("user rejected the request.")
         else:

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -88,7 +88,7 @@ class Result:
     """Result data of a swift-call.
     
     Fields:
-        done: Whether the swift-call is done. True when the it has failed as well.
+        done: Whether the swift-call is done. Even when it failed, this is True as well.
         success: True when the swift-call is done without any problems.
         value: Return value of the swift-call, if any. It must be converted to a JSON string.
         error: Information about the problem that occurred during the swift-call.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -15,9 +15,9 @@ import argparse
 import json
 import importlib
 import importlib.util
+import dataclasses
 from collections import defaultdict
 from contextlib import contextmanager
-from dataclasses import dataclass, asdict
 from typing import (
     Dict, Any, Iterable, Mapping, Optional, TypeVar, Type
 )
@@ -29,7 +29,7 @@ from PyQt5.QtWidgets import QApplication, QMainWindow, QLabel, QDockWidget, QMes
 T = TypeVar("T")
 
 
-@dataclass
+@dataclasses.dataclass
 class AppInfo:
     """Information required to create an app.
     
@@ -80,10 +80,10 @@ def strinfo(info: AppInfo) -> str:
     Args:
         info: Dataclass object to convert to a JSON string.
     """
-    return json.dumps(asdict(info))
+    return json.dumps(dataclasses.asdict(info))
 
 
-@dataclass
+@dataclasses.dataclass
 class Result:
     """Result data of a swift-call.
     

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -245,7 +245,7 @@ class Swift(QObject):
             if reply == QMessageBox.Ok:
                 return self.createApp(name, AppInfo(**info))
             raise RuntimeError("user rejected the request.")
-        elif action == "destroy":
+        if action == "destroy":
             name = args["name"]
             reply = QMessageBox.warning(
                 None,
@@ -257,8 +257,7 @@ class Swift(QObject):
             if reply == QMessageBox.Ok:
                 return self.destroyApp(name)
             raise RuntimeError("user rejected the request.")
-        else:
-            raise NotImplementedError(action)
+        raise NotImplementedError(action)
 
     @pyqtSlot(str)
     def _swiftcall(self, msg: str):

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -205,8 +205,7 @@ class Swift(QObject):
         for app in self._subscribers[channelName]:
             app.received.emit(channelName, msg)
 
-    @pyqtSlot(str)
-    def _swiftcall(self, msg: str):
+    def _handleSwiftcall(self, msg: str) -> Any:
         """Handles the swift-call.
 
         This can raise an exception if the arguments do not follow the valid API.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -165,7 +165,7 @@ class Swift(QObject):
         app.broadcastRequested.connect(self._broadcast, type=Qt.QueuedConnection)
         app.swiftcallRequested.connect(
             functools.partial(self._swiftcall, name),
-            type=Qt.QueuedConnection
+            type=Qt.QueuedConnection,
         )
         for channelName in info.channel:
             self._subscribers[channelName].add(app)

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -95,8 +95,8 @@ class Result:
     """
     done: bool
     success: bool
-    value: Any
-    error: Optional[str]
+    value: Any = None
+    error: Optional[str] = None
 
 
 class Swift(QObject):

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -85,7 +85,7 @@ def strinfo(info: AppInfo) -> str:
 
 
 @dataclasses.dataclass
-class Result:
+class SwiftcallResult:
     """Result data of a swift-call.
     
     Fields:
@@ -275,9 +275,9 @@ class Swift(QObject):
         try:
             value = self._handleSwiftcall(sender, msg)
         except Exception as error:  # pylint: disable=broad-exception-caught
-            result = Result(done=True, success=False, error=repr(error))
+            result = SwiftcallResult(done=True, success=False, error=repr(error))
         else:
-            result = Result(done=True, success=True, value=value)
+            result = SwiftcallResult(done=True, success=True, value=value)
         self._apps[sender].swiftcallReturned.emit(msg, json.dumps(dataclasses.asdict(result)))
 
 

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -258,21 +258,23 @@ class Swift(QObject):
             raise RuntimeError("user rejected the request.")
         raise NotImplementedError(action)
 
-    @pyqtSlot(str)
-    def _swiftcall(self, msg: str):
-        """Slot for the swiftcallRequested signal.
+    def _swiftcall(self, sender: str, msg: str):
+        """Will be connected to the swiftcallRequested signal.
+
+        Note that swiftcallRequested signal only has one str argument.
+        In fact the partial method will be connected using functools.partial().
 
         Args:
+            sender: See _handleSwiftcall().
             msg: See _handleSwiftcall().
         """
-        sender = self.sender()
         try:
-            value = self._handleSwiftcall(sender.name, msg)
+            value = self._handleSwiftcall(sender, msg)
         except Exception as error: # pylint: disable=broad-exception-caught
             result = Result(done=True, success=False, error=repr(error))
         else:
             result = Result(done=True, success=True, value=value)
-        sender.swiftcallReturned.emit(msg, json.dumps(dataclasses.asdict(result)))
+        self._apps[sender].swiftcallReturned.emit(msg, json.dumps(dataclasses.asdict(result)))
 
 
 @contextmanager

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -90,7 +90,7 @@ class Result:
     Fields:
         done: Whether the swift-call is done. Even when it failed, this is True as well.
         success: True when the swift-call is done without any problems.
-        value: Return value of the swift-call, if any. It must be converted to a JSON string.
+        value: Return value of the swift-call, if any. It must be JSONifiable.
         error: Information about the problem that occurred during the swift-call.
     """
     done: bool
@@ -226,7 +226,6 @@ class Swift(QObject):
         
         Raises:
             RuntimeError: When the user rejects the request.
-            NotImplementedError: When the given request action is not implemented.
         
         Returns:
             The returned value of the swift-call, if any.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -16,6 +16,7 @@ import json
 import importlib
 import importlib.util
 import dataclasses
+import functools
 from collections import defaultdict
 from contextlib import contextmanager
 from typing import (
@@ -162,7 +163,10 @@ class Swift(QObject):
         else:
             app = cls(name, parent=self)
         app.broadcastRequested.connect(self._broadcast, type=Qt.QueuedConnection)
-        app.swiftcallRequested.connect(self._swiftcall, type=Qt.QueuedConnection)
+        app.swiftcallRequested.connect(
+            functools.partial(self._swiftcall, name),
+            type=Qt.QueuedConnection
+        )
         for channelName in info.channel:
             self._subscribers[channelName].add(app)
         for frame in app.frames():

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -84,20 +84,6 @@ def strinfo(info: AppInfo) -> str:
 
 
 @dataclasses.dataclass
-class SwiftcallInfo:
-    """Information specifying a swiftcall.
-    
-    Fields:
-        call: Swiftcall method name, e.g., "createApp". It should be a valid
-          public method name of a Swift instance.
-        args: Arguments for the call, all as keyword arguments. The arguments
-          should follow the public API as well.
-    """
-    call: str
-    args: Mapping[str, Any] = dataclasses.field(default_factory=dict)
-
-
-@dataclasses.dataclass
 class Result:
     """Result data of a swift-call.
     


### PR DESCRIPTION
I implemented the interface for getting swift-call results.

Few insights:
1. The `Result` class will be used in apps to manage the swift-calls in the future. It will be implemented maybe in #136.
2. [`QObject.sender()`](https://doc.qt.io/qt-5/qobject.html#sender) is convenient, but we have to be careful as the document says, which implies that it easily breaks our assumptions and intuition. For example, consider the case where a slot is not called by a signal.
> Warning: This function violates the object-oriented principle of modularity.

3. Pylint complains about catching `Exception`. However, I intended to do that, so I applied [this solution](https://stackoverflow.com/a/64040518).
4. In a function docstring, we don't document the exceptions raised when the input violates the documented condition.

This closes #131.