### PR TITLE
Generalize swift call message protocol

### DIFF
--- a/swift/swift.py
+++ b/swift/swift.py
@@ -106,6 +106,9 @@ class SwiftcallInfo(Serializable):
           This is case-sensitive.
         args: The arguments of the swift-call as a dictionary of keyword arguements.
           The names of the arguements are case-sensitive.
+          When an argument is Serializable, it must be given as a converted JSON string,
+          e.g., not {"arg": SwiftcallInfo(call="call")},
+          but {"arg": '{"call": "call", "args": {}}'}.
     """
     call: str
     args: Mapping[str] = dataclasses.field(default_factory=dict)

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -89,15 +89,13 @@ def parse(cls: Type[T], kwargs: str) -> T:
 
 # TODO(kangz12345): Method name looks too specific.
 # Change this to dumps() whenever we can rename this symbol.
-def strinfo(info: Serializable) -> str:
-    """Returns a JSON string converted from the given info.
-
-    This is just a convenience function for users not to import dataclasses and json.
+def strinfo(obj: Serializable) -> str:
+    """Returns a JSON string converted from the given Serializable object.
     
     Args:
-        info: Dataclass object to convert to a JSON string.
+        obj: Dataclass object to convert to a JSON string.
     """
-    return json.dumps(dataclasses.asdict(info))
+    return json.dumps(dataclasses.asdict(obj))
 
 
 @dataclasses.dataclass

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -15,12 +15,13 @@ import argparse
 import json
 import importlib
 import importlib.util
+import inspect
 import dataclasses
 import functools
 from collections import defaultdict
 from contextlib import contextmanager
 from typing import (
-    Dict, Any, Iterable, Mapping, Optional, TypeVar, Type
+    Dict, Any, Callable, Iterable, Mapping, Optional, TypeVar, Type
 )
 
 from PyQt5.QtCore import QObject, pyqtSlot, Qt

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -114,7 +114,7 @@ class SwiftcallInfo(Serializable):
           but {"arg": '{"call": "call", "args": {}}'}.
     """
     call: str
-    args: Mapping[str] = dataclasses.field(default_factory=dict)
+    args: Mapping[str, Any] = dataclasses.field(default_factory=dict)
 
 
 @dataclasses.dataclass
@@ -242,7 +242,7 @@ class Swift(QObject):
         for app in self._subscribers[channelName]:
             app.received.emit(channelName, msg)
 
-    def _parseArgs(self, call: Callable, args: Mapping[str]) -> Dict[str]:
+    def _parseArgs(self, call: Callable, args: Mapping[str, Any]) -> Dict[str, Any]:
         """Converts all Serializable arguments to dataclass objects from strings.
 
         It checks the function signature of the call and converts the JSON string

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -283,6 +283,8 @@ class Swift(QObject):
             The returned value of the swift-call, if any.
         """
         info = parse(SwiftcallInfo, msg)
+        if info.call.startswith("_"):
+            raise ValueError("Only public method calls are allowed.")
         call = getattr(self, info.call)
         args = self._parseArgs(call, info.args)
         reply = QMessageBox.warning(

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -30,6 +30,17 @@ from PyQt5.QtWidgets import QApplication, QMainWindow, QLabel, QDockWidget, QMes
 T = TypeVar("T")
 
 
+class Serializable:
+    """A type for dataclasses that can be converted to a JSON string.
+    
+    The message protocols in swift use JSON strings to encode data.
+    If a dataclass inherits this class, the dictionary yielded by asdict() must
+      be able to converted to a JSON string, i.e., JSONifiable.
+    Every argument of swift-calls must be JSONifiable by itself
+      or an instance of Serializable.
+    """
+
+
 @dataclasses.dataclass
 class AppInfo:
     """Information required to create an app.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -85,6 +85,20 @@ def strinfo(info: AppInfo) -> str:
 
 
 @dataclasses.dataclass
+class SwiftcallInfo:
+    """Information of a swift-call request.
+    
+    Fields:
+        call: The name of the swift-call feature, e.g., "createApp" for createApp().
+          This is case-sensitive.
+        args: The arguments of the swift-call as a dictionary of keyword arguements.
+          The names of the arguements are case-sensitive.
+    """
+    call: str
+    args: Mapping[str] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass
 class SwiftcallResult:
     """Result data of a swift-call.
     

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -305,7 +305,7 @@ class Swift(QObject):
             result = SwiftcallResult(done=True, success=False, error=repr(error))
         else:
             result = SwiftcallResult(done=True, success=True, value=value)
-        self._apps[sender].swiftcallReturned.emit(msg, json.dumps(dataclasses.asdict(result)))
+        self._apps[sender].swiftcallReturned.emit(msg, strinfo(result))
 
 
 @contextmanager

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -69,7 +69,8 @@ class AppInfo(Serializable):
     args: Optional[Mapping[str, Any]] = None
 
 
-# TODO(kangz12345): Make this and strinfo() a pair. Change this to loads() whenever we can rename this symbol.
+# TODO(kangz12345): Make this and strinfo() a pair.
+# Change this to loads() whenever we can rename this symbol.
 def parse(cls: Type[T], kwargs: str) -> T:
     """Returns a new cls instance from a JSON string.
 
@@ -86,7 +87,8 @@ def parse(cls: Type[T], kwargs: str) -> T:
     return cls(**json.loads(kwargs))
 
 
-# TODO(kangz12345): Method name looks too specific. Change this to dumps() whenever we can rename this symbol.
+# TODO(kangz12345): Method name looks too specific.
+# Change this to dumps() whenever we can rename this symbol.
 def strinfo(info: Serializable) -> str:
     """Returns a JSON string converted from the given info.
 

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -110,7 +110,7 @@ class SwiftcallInfo(Serializable):
 
 
 @dataclasses.dataclass
-class SwiftcallResult:
+class SwiftcallResult(Serializable):
     """Result data of a swift-call.
     
     Fields:

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -314,6 +314,8 @@ class Swift(QObject):
         except Exception as error:  # pylint: disable=broad-exception-caught
             result = SwiftcallResult(done=True, success=False, error=repr(error))
         else:
+            if isinstance(value, Serializable):
+                value = strinfo(value)
             result = SwiftcallResult(done=True, success=True, value=value)
         self._apps[sender].swiftcallReturned.emit(msg, strinfo(result))
 

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -31,7 +31,7 @@ from PyQt5.QtWidgets import QApplication, QMainWindow, QLabel, QDockWidget, QMes
 T = TypeVar("T")
 
 
-class Serializable:
+class Serializable:  # pylint: disable=too-few-public-methods
     """A type for dataclasses that can be converted to a JSON string.
     
     The message protocols in swift use JSON strings to encode data.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -69,9 +69,7 @@ class AppInfo(Serializable):
     args: Optional[Mapping[str, Any]] = None
 
 
-# TODO(kangz12345): Make this and strinfo() a pair.
-# Change this to loads() whenever we can rename this symbol.
-def parse(cls: Type[T], kwargs: str) -> T:
+def loads(cls: Type[T], kwargs: str) -> T:
     """Returns a new cls instance from a JSON string.
 
     This is a convenience function for just unpacking the JSON string and gives them
@@ -260,7 +258,7 @@ class Swift(QObject):
         parsedArgs = {}
         for name, arg in args.items():
             cls = signature.parameters[name].annotation
-            parsedArgs[name] = parse(cls, arg) if isinstance(cls, Serializable) else arg
+            parsedArgs[name] = loads(cls, arg) if isinstance(cls, Serializable) else arg
         return parsedArgs
 
     def _handleSwiftcall(self, sender: str, msg: str) -> Any:
@@ -281,7 +279,7 @@ class Swift(QObject):
         Returns:
             The returned value of the swift-call, if any.
         """
-        info = parse(SwiftcallInfo, msg)
+        info = loads(SwiftcallInfo, msg)
         if info.call.startswith("_"):
             raise ValueError("Only public method calls are allowed.")
         call = getattr(self, info.call)

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -68,6 +68,7 @@ class AppInfo(Serializable):
     args: Optional[Mapping[str, Any]] = None
 
 
+# TODO(kangz12345): Make this and strinfo() a pair. Change this to loads() whenever we can rename this symbol.
 def parse(cls: Type[T], kwargs: str) -> T:
     """Returns a new cls instance from a JSON string.
 
@@ -84,6 +85,7 @@ def parse(cls: Type[T], kwargs: str) -> T:
     return cls(**json.loads(kwargs))
 
 
+# TODO(kangz12345): Method name looks too specific. Change this to dumps() whenever we can rename this symbol.
 def strinfo(info: Serializable) -> str:
     """Returns a JSON string converted from the given info.
 

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -42,7 +42,7 @@ class Serializable:
 
 
 @dataclasses.dataclass
-class AppInfo:
+class AppInfo(Serializable):
     """Information required to create an app.
     
     Fields:
@@ -84,7 +84,7 @@ def parse(cls: Type[T], kwargs: str) -> T:
     return cls(**json.loads(kwargs))
 
 
-def strinfo(info: AppInfo) -> str:
+def strinfo(info: Serializable) -> str:
     """Returns a JSON string converted from the given info.
 
     This is just a convenience function for users not to import dataclasses and json.
@@ -96,7 +96,7 @@ def strinfo(info: AppInfo) -> str:
 
 
 @dataclasses.dataclass
-class SwiftcallInfo:
+class SwiftcallInfo(Serializable):
     """Information of a swift-call request.
     
     Fields:

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -71,10 +71,7 @@ class AppInfo(Serializable):
 
 def loads(cls: Type[T], kwargs: str) -> T:
     """Returns a new cls instance from a JSON string.
-
-    This is a convenience function for just unpacking the JSON string and gives them
-    as keyword arguments of the constructor of cls.
-        
+    
     Args:
         cls: A class object.
         kwargs: A JSON string of a dictionary that contains the keyword arguments of cls.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -261,7 +261,7 @@ class Swift(QObject):
             dataclass instances instead of JSON strings.
         """
         signature = inspect.signature(call)
-        parsedArgs = dict()
+        parsedArgs = {}
         for name, arg in args.items():
             cls = signature.parameters[name].annotation
             parsedArgs[name] = parse(cls, arg) if isinstance(cls, Serializable) else arg

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -87,9 +87,7 @@ def parse(cls: Type[T], kwargs: str) -> T:
     return cls(**json.loads(kwargs))
 
 
-# TODO(kangz12345): Method name looks too specific.
-# Change this to dumps() whenever we can rename this symbol.
-def strinfo(obj: Serializable) -> str:
+def dumps(obj: Serializable) -> str:
     """Returns a JSON string converted from the given Serializable object.
     
     Args:
@@ -315,9 +313,9 @@ class Swift(QObject):
             result = SwiftcallResult(done=True, success=False, error=repr(error))
         else:
             if isinstance(value, Serializable):
-                value = strinfo(value)
+                value = dumps(value)
             result = SwiftcallResult(done=True, success=True, value=value)
-        self._apps[sender].swiftcallReturned.emit(msg, strinfo(result))
+        self._apps[sender].swiftcallReturned.emit(msg, dumps(result))
 
 
 @contextmanager

--- a/tests/test_swift.py
+++ b/tests/test_swift.py
@@ -116,8 +116,8 @@ class SwiftFunctionTest(unittest.TestCase):
         self.assertEqual(swift.parse(swift.AppInfo, APP_JSONS["app2_default"]), APP_INFOS["app2"])
 
     def test_strinfo(self):
-        self.assertEqual(swift.strinfo(APP_INFOS["app1"]), APP_JSONS["app1"])
-        self.assertEqual(swift.strinfo(APP_INFOS["app2"]), APP_JSONS["app2"])
+        self.assertEqual(swift.dumps(APP_INFOS["app1"]), APP_JSONS["app1"])
+        self.assertEqual(swift.dumps(APP_INFOS["app2"]), APP_JSONS["app2"])
 
     def test_add_to_path(self):
         test_dir = "/test_dir"

--- a/tests/test_swift.py
+++ b/tests/test_swift.py
@@ -110,10 +110,10 @@ class SwiftFunctionTest(unittest.TestCase):
     """Unit test for functions in swift.py"""
 
     def test_parse(self):
-        self.assertEqual(swift.parse(swift.AppInfo, APP_JSONS["app1"]), APP_INFOS["app1"])
+        self.assertEqual(swift.loads(swift.AppInfo, APP_JSONS["app1"]), APP_INFOS["app1"])
 
     def test_parse_default(self):
-        self.assertEqual(swift.parse(swift.AppInfo, APP_JSONS["app2_default"]), APP_INFOS["app2"])
+        self.assertEqual(swift.loads(swift.AppInfo, APP_JSONS["app2_default"]), APP_INFOS["app2"])
 
     def test_strinfo(self):
         self.assertEqual(swift.dumps(APP_INFOS["app1"]), APP_JSONS["app1"])


### PR DESCRIPTION
I refactored `_handleSwiftcall()` to accept more general method calls.

Summary:

1. I introduced `Serializable` class to indicate the dataclasses that are able to converted to JSON strings. All the public methods should have parameters that are JSONifiable by itself or an instance of `Serializable`.
2. `_parseArgs()` inspects the function signature of the public API methods, and converts arguments from JSON strings to concrete dataclass instances in the parameter type is `Serializable`.

However, I have not tested the actual behavior yet...

This closes #139.