### PR TITLE
Kangz12345/136/simplify swift call request

### DIFF
--- a/swift/app.py
+++ b/swift/app.py
@@ -91,7 +91,7 @@ class BaseApp(QObject):
             self.receivedSlot(channelName, content)
 
 
-class SwiftcallProxy:
+class SwiftcallProxy:  # pylint: disable=too-few-public-methods
     """A proxy for requesting swift-calls conveniently.
     
     Every attribute access is proxied, and if you try to call a method of this

--- a/swift/app.py
+++ b/swift/app.py
@@ -140,3 +140,19 @@ class SwiftcallProxy:  # pylint: disable=too-few-public-methods
             self.requested.emit(msg)
             return result
         return proxy
+
+    def update_result(self, request: str, result: swift.SwiftcallResult):
+        """Updates the result for the request parsing the received message.
+
+        Args:
+            request: The request message that has been sent to Swift.
+            result: The received result object.
+        """
+        _result = self.results.get(request, None)
+        if _result is None:
+            print(f"SwiftcallProxy._update_result: Failed to find a result for {request}.")
+            return
+        _result.error = result.error
+        _result.value = result.value
+        _result.success = result.success
+        _result.done = result.done

--- a/swift/app.py
+++ b/swift/app.py
@@ -158,6 +158,8 @@ class SwiftcallProxy:  # pylint: disable=too-few-public-methods
             info = swift.SwiftcallInfo(call=call, args=args)
             result = swift.SwiftcallResult(done=False, success=False)
             msg = swift.dumps(info)
+            if msg in self.results:
+                print(f"SwiftcallProxy.<local>.proxy(): Duplicate message {msg} is ignored.")
             self.results[msg] = result
             self.requested.emit(msg)
             return result

--- a/swift/app.py
+++ b/swift/app.py
@@ -174,7 +174,7 @@ class SwiftcallProxy:  # pylint: disable=too-few-public-methods
         """
         _result = self.results.get(request, None)
         if _result is None:
-            print(f"SwiftcallProxy._update_result: Failed to find a result for {request}.")
+            print(f"SwiftcallProxy.update_result(): Failed to find a result for {request}.")
             return
         _result.error = result.error
         _result.value = result.value

--- a/swift/app.py
+++ b/swift/app.py
@@ -98,6 +98,17 @@ class SwiftcallProxy:
     does the same thing as calling a method of this object.
     """
 
+    def __init__(self, requested: QObject, returned: QObject):
+        """
+        Args:
+            requested: A pyqtSignal(str) which will be emitted when a proxied
+              method call is invoked. See BaseApp.swiftcallRequested.
+            returned: A pyqtSignal(str, str) to which slots will be connected.
+              See BaseApp.swiftcallReturned.
+        """
+        self.requested = requested
+        self.returned = returned
+
     def __getattribute__(self, call: str) -> Callable:
         """Returns a callable object which emits a swift-call requesting signal.
 

--- a/swift/app.py
+++ b/swift/app.py
@@ -14,10 +14,10 @@ class BaseApp(QObject):
     """Base App class that all apps should inherit.
 
     Signals: 
-        broadcastRequested(str, str): A signal for broadcasting to a channel 
-          which contains the target channel name and the message.
-        received(str, str): A signal for receiving a global signal from a channel
-          which contains the source channel name and the message.
+        broadcastRequested(str, str): The app requested broadcasting to a channel 
+          with the target channel name and the message.
+        received(str, str): A message is received from a channel which contains
+          the source channel name and the message.
         swiftcallRequested(str): The app requested a swiftcall with a string
           message converted from a swift.SwiftcallInfo object by swift.dumps().
         swiftcallReturned(str, str): The result of the requested swift-call

--- a/swift/app.py
+++ b/swift/app.py
@@ -25,6 +25,10 @@ class BaseApp(QObject):
         swiftcallReturned(str, str): The result of the requested swift-call
           with the original requested message and the result message converted
           from a swift.SwiftcallResult object by swift.dumps().
+    
+    Attributes:
+        name: The string identifier name of this app.
+        swiftcall: A swift-call proxy for requesting swift-calls conveniently.
     """
 
     broadcastRequested = pyqtSignal(str, str)

--- a/swift/app.py
+++ b/swift/app.py
@@ -19,8 +19,9 @@ class BaseApp(QObject):
         broadcastRequested(channel, message): The app can emit this signal to request
           broadcasting to a channel with the target channel name and the message.
         received(channel, message): A broadcast message is received from a channel.
-        swiftcallRequested(str): The app requested a swiftcall with a string
-          message converted from a swift.SwiftcallInfo object by swift.dumps().
+        swiftcallRequested(request): The app can emit this signal to request
+          a swift-call with a request message converted from a swift.SwiftcallInfo
+          object by swift.dumps().
         swiftcallReturned(str, str): The result of the requested swift-call
           with the original requested message and the result message converted
           from a swift.SwiftcallResult object by swift.dumps().

--- a/swift/app.py
+++ b/swift/app.py
@@ -5,7 +5,7 @@ Every App class should be a subclass of BaseApp.
 """
 
 import json
-from typing import Any, Optional, Iterable
+from typing import Any, Optional, Callable, Iterable
 
 from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import QWidget
@@ -84,3 +84,20 @@ class BaseApp(QObject):
             print(f"swift.app._receivedMessage(): {e!r}")
         else:
             self.receivedSlot(channelName, content)
+
+
+class SwiftcallProxy:
+    """A proxy for requesting swift-calls conveniently.
+    
+    Every attribute access is proxied, and if you try to call a method of this
+    object, it will emit a swift-call requesting signal instead.
+    If you get an attribute of this object, you will get a callable object which
+    does the same thing as calling a method of this object.
+    """
+
+    def __getattribute__(self, call: str) -> Callable:
+        """Returns a callable object which emits a swift-call requesting signal.
+
+        Args:
+            call: The name of the swift-call.
+        """

--- a/swift/app.py
+++ b/swift/app.py
@@ -100,17 +100,13 @@ class SwiftcallProxy:  # pylint: disable=too-few-public-methods
     does the same thing as calling a method of this object.
     """
 
-    def __init__(self, requested: QObject, returned: QObject):
+    def __init__(self, requested: QObject):
         """
         Args:
             requested: A pyqtSignal(str) which will be emitted when a proxied
               method call is invoked. See BaseApp.swiftcallRequested.
-            returned: A pyqtSignal(str, str) to which slots will be connected.
-              See BaseApp.swiftcallReturned.
         """
         self.requested = requested
-        self.returned = returned
-        self.results = {}
 
     def __getattr__(self, call: str) -> Callable:
         """Returns a callable object which emits a swift-call requesting signal.

--- a/swift/app.py
+++ b/swift/app.py
@@ -112,7 +112,7 @@ class SwiftcallProxy:  # pylint: disable=too-few-public-methods
         self.returned = returned
         self.results = {}
 
-    def __getattribute__(self, call: str) -> Callable:
+    def __getattr__(self, call: str) -> Callable:
         """Returns a callable object which emits a swift-call requesting signal.
 
         Args:

--- a/swift/app.py
+++ b/swift/app.py
@@ -18,8 +18,11 @@ class BaseApp(QObject):
           which contains the target channel name and the message.
         received(str, str): A signal for receiving a global signal from a channel
           which contains the source channel name and the message.
-        TODO(kangz12345): docstring for swiftcallRequested and swiftcallReturned.
-          They should be written when the swiftcall protocol is finally determined.
+        swiftcallRequested(str): The app requested a swiftcall with a string
+          message converted from a swift.SwiftcallInfo object by swift.dumps().
+        swiftcallReturned(str, str): The result of the requested swift-call
+          with the original requested message and the result message converted
+          from a swift.SwiftcallResult object by swift.dumps().
     """
 
     broadcastRequested = pyqtSignal(str, str)

--- a/swift/app.py
+++ b/swift/app.py
@@ -165,14 +165,19 @@ class SwiftcallProxy:  # pylint: disable=too-few-public-methods
             return result
         return proxy
 
-    def update_result(self, request: str, result: swift.SwiftcallResult):
+    def update_result(self, request: str, result: swift.SwiftcallResult, discard: bool = True):
         """Updates the result for the request parsing the received message.
 
         Args:
             request: The request message that has been sent to Swift.
             result: The received result object.
+            discard: If True, the result object is removed from self.results.
+              In most cases, it will be updated only once and never be looked up again.
+              Therefore, it is efficient to discard it after updating the result.
+              If you want to find the result from self.results later again, give False.
         """
-        _result = self.results.get(request, None)
+        _get_result = self.results.pop if discard else self.results.get
+        _result = _get_result(request, None)
         if _result is None:
             print(f"SwiftcallProxy.update_result(): Failed to find a result for {request}.")
             return

--- a/swift/app.py
+++ b/swift/app.py
@@ -133,9 +133,9 @@ class SwiftcallProxy:
             Returns:
                 A swift-call result object to keep tracking the result.
             """
-            for name in args:
-                if isinstance(args[name], swift.Serializable):
-                    args[name] = swift.dumps(args[name])
+            for name, arg in args.items():
+                if isinstance(arg, swift.Serializable):
+                    args[name] = swift.dumps(arg)
             info = swift.SwiftcallInfo(call=call, args=args)
             result = swift.SwiftcallResult(done=False, success=False)
             msg = swift.dumps(info)

--- a/swift/app.py
+++ b/swift/app.py
@@ -46,7 +46,7 @@ class BaseApp(QObject):
         self.name = name
         self.swiftcall = SwiftcallProxy(self.swiftcallRequested)
         self.received.connect(self._receivedMessage)
-        self.swiftcallReturned.connect(self._receivedResult)
+        self.swiftcallReturned.connect(self._receivedSwiftcallResult)
 
     def frames(self) -> Iterable[QWidget]:
         """Gets frames for which are managed by the App.
@@ -97,7 +97,7 @@ class BaseApp(QObject):
             self.receivedSlot(channelName, content)
 
     @pyqtSlot(str, str)
-    def _receivedResult(self, request: str, msg: str):
+    def _receivedSwiftcallResult(self, request: str, msg: str):
         """This is connected to self.swiftcallReturned signal.
 
         Args:

--- a/swift/app.py
+++ b/swift/app.py
@@ -16,10 +16,9 @@ class BaseApp(QObject):
     """Base App class that all apps should inherit.
 
     Signals: 
-        broadcastRequested(str, str): The app requested broadcasting to a channel 
-          with the target channel name and the message.
-        received(str, str): A message is received from a channel which contains
-          the source channel name and the message.
+        broadcastRequested(channel, message): The app can emit this signal to request
+          broadcasting to a channel with the target channel name and the message.
+        received(channel, message): A broadcast message is received from a channel.
         swiftcallRequested(str): The app requested a swiftcall with a string
           message converted from a swift.SwiftcallInfo object by swift.dumps().
         swiftcallReturned(str, str): The result of the requested swift-call

--- a/swift/app.py
+++ b/swift/app.py
@@ -22,7 +22,7 @@ class BaseApp(QObject):
         swiftcallRequested(request): The app can emit this signal to request
           a swift-call with a request message converted from a swift.SwiftcallInfo
           object by swift.dumps().
-        swiftcallReturned(str, str): The result of the requested swift-call
+        swiftcallReturned(request, result): The result of the requested swift-call
           with the original requested message and the result message converted
           from a swift.SwiftcallResult object by swift.dumps().
     

--- a/swift/app.py
+++ b/swift/app.py
@@ -5,7 +5,7 @@ Every App class should be a subclass of BaseApp.
 """
 
 import json
-from typing import Any, Optional, Callable, Iterable
+from typing import Any, Dict, Optional, Callable, Iterable
 
 from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot
 from PyQt5.QtWidgets import QWidget
@@ -107,6 +107,7 @@ class SwiftcallProxy:  # pylint: disable=too-few-public-methods
               method call is invoked. See BaseApp.swiftcallRequested.
         """
         self.requested = requested
+        self.results: Dict[str, swift.SwiftcallResult] = {}
 
     def __getattr__(self, call: str) -> Callable:
         """Returns a callable object which emits a swift-call requesting signal.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -255,7 +255,7 @@ class Swift(QObject):
         parsedArgs = {}
         for name, arg in args.items():
             cls = signature.parameters[name].annotation
-            parsedArgs[name] = loads(cls, arg) if isinstance(cls, Serializable) else arg
+            parsedArgs[name] = loads(cls, arg) if issubclass(cls, Serializable) else arg
         return parsedArgs
 
     def _handleSwiftcall(self, sender: str, msg: str) -> Any:


### PR DESCRIPTION
I implemented the simplified swift-call interface.
The newly introduced usage is as follows:
1. Every `BaseApp` has a new attribute: `swiftcall`.
2. From that, one can _call_ any swift-call just like calling a method, e.g., `self.swiftcall.destroyApp(name="logger")`. All the arguments must be given as keyword arguments, for clarity.
3. It will return a `SwiftcallResult` instance. It is updated when the swift-call is done and the result comes back via the `swiftcallReturned` signal. One may want to keep it to check the result, e.g.:
```python
result = self.swiftcall.destroyApp(name="logger")
...
if result.done:
  if result.success:
    print(f"returned value is {result.value}.")
  else:
    print(f"failed: {result.error}.")
```

4. One must not _block_ on the result to be done, e.g., `while not result.done: ...`, in the main thread, since it will freeze the entire GUI process.

I have tested `createApp()` and `destroyApp()`.
As I test it, I fixed a bug in `swift` module that I implemented in #142.

This closes #136.