### PR TITLE
Implement swift-call 'updateFrames()' which updates frames of the app

### DIFF
--- a/swift/swift.py
+++ b/swift/swift.py
@@ -233,12 +233,11 @@ class Swift(QObject):
             apps.discard(app)
         app.deleteLater()
 
-    def updateFrames(self, name: str, update: bool = False):
+    def updateFrames(self, name: str):
         """Updates the frames of an app.
         
         Args:
             name: A name of the app to update its frames.
-            update: Whether the original frames will be updated or remained.
         """
         app = self._apps[name]
         info = self.appInfos[name]
@@ -246,11 +245,11 @@ class Swift(QObject):
         newFrames = app.frames()
         orgFramesSet = set(orgFrames)
         newFramesSet = set(newFrames)
-        for frame in orgFramesSet if update else orgFramesSet - newFramesSet:
+        for frame in orgFramesSet - newFramesSet:
             dockWidget = orgFrames[frame]
             self.mainWindow.removeDockWidget(dockWidget)
             dockWidget.deleteLater()
-        for frame in newFramesSet if update else newFramesSet - orgFramesSet:
+        for frame in newFramesSet - orgFramesSet:
             self.addFrame(name, frame, info)
 
     @pyqtSlot(str, str)

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -222,8 +222,18 @@ class Swift(QObject):
             apps.discard(app)
         app.deleteLater()
 
-    def updateFrames(self, name: str):
-        print("Called updateFrames()")
+    def updateFrames(self, name: str, update: bool = False):
+        """Updates the frames of an app.
+        
+        Args:
+            name: A name of the app to update its frames.
+            update: Whether the original frames will be updated or remained.
+        """
+        app = self._apps[name]
+        orgFrames = [dockWidget.widget() for dockWidget in self._dockWidgets[name]]
+        for frame in app.frames():
+            if not update and frame in orgFrames:
+                continue
 
     @pyqtSlot(str, str)
     def _broadcast(self, channelName: str, msg: str):

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -195,7 +195,14 @@ class Swift(QObject):
             self.mainWindow.addDockWidget(area, dockWidget)
         self._dockWidgets[name].append(dockWidget)
 
-    def deleteFrame(self, dockWidget: QDockWidget):
+    def removeFrame(self, dockWidget: QDockWidget):
+        """Removes the frame from the main window.
+        
+        This is not a swift-call because QDockWidget is not Serializable.
+        
+        Args:
+            dockWidget: A dock widget to remove.
+        """
         self.mainWindow.removeDockWidget(dockWidget)
         dockWidget.deleteLater()
 
@@ -232,7 +239,7 @@ class Swift(QObject):
         """
         dockWidgets = self._dockWidgets.pop(name)
         for dockWidget in dockWidgets:
-            self.deleteFrame(dockWidget)
+            self.removeFrame(dockWidget)
         app = self._apps.pop(name)
         for apps in self._subscribers.values():
             apps.discard(app)
@@ -251,7 +258,7 @@ class Swift(QObject):
         orgFramesSet = set(orgFrames)
         newFramesSet = set(newFrames)
         for frame in orgFramesSet - newFramesSet:
-            self.deleteFrame(orgFrames[frame])
+            self.removeFrame(orgFrames[frame])
         for frame in newFramesSet - orgFramesSet:
             self.addFrame(name, frame, info)
 

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -222,6 +222,9 @@ class Swift(QObject):
             apps.discard(app)
         app.deleteLater()
 
+    def updateFrames(self, name: str):
+        print("Called updateFrames()")
+
     @pyqtSlot(str, str)
     def _broadcast(self, channelName: str, msg: str):
         """Broadcasts the message to the subscriber apps of the channel.

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -175,6 +175,8 @@ class Swift(QObject):
 
     def addFrame(self, name: str, frame: QWidget, info: AppInfo):
         """Adds a frame of the app and wraps it with a dock widget.
+
+        This is not a swift-call because QWidget is not Serializable.
         
         Args:
             name: A name of app.
@@ -192,6 +194,10 @@ class Swift(QObject):
         if info.show:
             self.mainWindow.addDockWidget(area, dockWidget)
         self._dockWidgets[name].append(dockWidget)
+
+    def deleteFrame(self, dockWidget: QDockWidget):
+        self.mainWindow.removeDockWidget(dockWidget)
+        dockWidget.deleteLater()
 
     def createApp(self, name: str, info: AppInfo):
         """Creates an app and shows their frames using set-up environment.
@@ -226,8 +232,7 @@ class Swift(QObject):
         """
         dockWidgets = self._dockWidgets.pop(name)
         for dockWidget in dockWidgets:
-            self.mainWindow.removeDockWidget(dockWidget)
-            dockWidget.deleteLater()
+            self.deleteFrame(dockWidget)
         app = self._apps.pop(name)
         for apps in self._subscribers.values():
             apps.discard(app)
@@ -246,9 +251,7 @@ class Swift(QObject):
         orgFramesSet = set(orgFrames)
         newFramesSet = set(newFrames)
         for frame in orgFramesSet - newFramesSet:
-            dockWidget = orgFrames[frame]
-            self.mainWindow.removeDockWidget(dockWidget)
-            dockWidget.deleteLater()
+            self.deleteFrame(orgFrames[frame])
         for frame in newFramesSet - orgFramesSet:
             self.addFrame(name, frame, info)
 

--- a/swift/swift.py
+++ b/swift/swift.py
@@ -239,7 +239,7 @@ class Swift(QObject):
         for frame in orgFramesSet if update else orgFramesSet - newFramesSet:
             dockWidget = orgFrames[frame]
             self.mainWindow.removeDockWidget(dockWidget)
-            dockWidget.deleteLater()        
+            dockWidget.deleteLater()
         for frame in newFramesSet if update else newFramesSet - orgFramesSet:
             dockWidget = QDockWidget(name, self.mainWindow)
             dockWidget.setWidget(frame)


### PR DESCRIPTION
This PR will close #149.

I implemented a swift-call `updateFrames()` which updates frames of the target app.

It has two arguments:
- name: the target app name
- update: If true, it will remove all original frames and add all new frames.
Otherwise, it will remove only 'original frames - new frames' and add only 'new frames - original frames', i.e. remain the intersection of original frames and new frames.