### PR TITLE
Testing swift-call-related codes

### DIFF
--- a/swift.py
+++ b/swift.py
@@ -352,7 +352,7 @@ class Swift(QObject):
         Args:
             sender: The name of the request sender app.
             msg: A JSON string that can be converted to SwiftcallInfo,
-              i.e., the same form as the returned string of strinfo().
+              i.e., the same form as the returned string of dumps().
               See SwiftcallInfo for details.
         
         Raises:

--- a/swift.py
+++ b/swift.py
@@ -348,6 +348,7 @@ class Swift(QObject):
 
         This can raise an exception if the arguments do not follow the valid API.
         The caller must obey the API and catch the possible exceptions.
+        Calling non-public methods are prohibitted.
 
         Args:
             sender: The name of the request sender app.
@@ -356,6 +357,8 @@ class Swift(QObject):
               See SwiftcallInfo for details.
         
         Raises:
+            ValueError: When the requested call is not public, i.e., starts with
+              an underscore (_).
             RuntimeError: When the user rejects the request.
         
         Returns:

--- a/test.py
+++ b/test.py
@@ -7,7 +7,7 @@ import sys
 import importlib
 import json
 import unittest
-from unittest.mock import MagicMock, patch, DEFAULT
+from unittest.mock import MagicMock, patch, DEFAULT, call
 from collections.abc import Iterable
 from typing import Any, Optional, Mapping
 

--- a/test.py
+++ b/test.py
@@ -2,6 +2,7 @@
 Module for testing swift module.
 """
 
+import dataclasses
 import sys
 import importlib
 import json
@@ -170,6 +171,34 @@ class SwiftTest(unittest.TestCase):
         args = {"arg_number": 1.5, "arg_bool": True, "arg_null": None, "arg_string": "abc"}
         parsed_args = self.swift._parseArgs(call_for_test, args)
         self.assertEqual(args, parsed_args)
+
+    def test_parse_args_serializable(self):
+        @dataclasses.dataclass
+        class ClassForTest(swift.Serializable):
+            field_number: float
+            field_bool: bool
+            field_null: None
+            field_string: str
+        def call_for_test(arg1: ClassForTest, arg2: ClassForTest):
+            """A dummy function for testing, which has only Serializable type arguments."""
+        fields1 = {
+            "field_number": 1.5,
+            "field_bool": True,
+            "field_null": None,
+            "field_string": "abc",
+        }
+        fields2 = {
+            "field_number": 0,
+            "field_bool": False,
+            "field_null": None,
+            "field_string": "",
+        }
+        arg1 = ClassForTest(**fields1)
+        arg2 = ClassForTest(**fields2)
+        args = {"arg1": arg1, "arg2": arg2}
+        parsed_args = self.swift._parseArgs(call_for_test, args)
+        self.assertEqual(json.dumps(fields1), parsed_args["arg1"])
+        self.assertEqual(json.dumps(fields2), parsed_args["arg2"])
 
 
 class BaseAppTest(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -201,11 +201,7 @@ class SwiftTest(unittest.TestCase):
             self.assertEqual(len(APP_INFOS[name].channel), app_.received.emit.call_count)
 
     def test_parse_args_primitive(self):
-        def call_for_test(
-            number: float,
-            boolean: bool,
-            string: str
-        ):  # pylint: disable=unused-argument
+        def call_for_test(number: float, boolean: bool, string: str):  # pylint: disable=unused-argument
             """A dummy function for testing, which has only primitive type arguments."""
         args = {"number": 1.5, "boolean": True, "string": "abc"}
         parsed_args = self.swift._parseArgs(call_for_test, args)

--- a/test.py
+++ b/test.py
@@ -404,7 +404,7 @@ class SwiftcallProxyTest(unittest.TestCase):
         with patch.object(self.swiftcall, "results", {"request": old_result}):
             self.swiftcall.update_result("request", new_result)
             self.assertEqual(old_result, new_result)
-            self.assertFalse(self.swiftcall.results)
+            self.assertNotIn("request", self.swiftcall.results)
 
     def test_update_result_error(self):
         old_result = swift.SwiftcallResult(done=False, success=False)
@@ -412,7 +412,7 @@ class SwiftcallProxyTest(unittest.TestCase):
         with patch.object(self.swiftcall, "results", {"request": old_result}):
             self.swiftcall.update_result("request", new_result)
             self.assertEqual(old_result, new_result)
-            self.assertFalse(self.swiftcall.results)
+            self.assertNotIn("request", self.swiftcall.results)
 
     def test_update_result_no_discard(self):
         old_result = swift.SwiftcallResult(done=False, success=False)

--- a/test.py
+++ b/test.py
@@ -2,12 +2,12 @@
 Module for testing swift module.
 """
 
+import collections.abc
 import dataclasses
 import sys
 import json
 import unittest
 from unittest import mock
-from collections.abc import Iterable
 from typing import Any, Optional, Mapping, Iterable
 
 from PyQt5.QtCore import QObject
@@ -343,7 +343,7 @@ class BaseAppTest(unittest.TestCase):
         swift.BaseApp("name", QObject())
 
     def test_frames(self):
-        self.assertIsInstance(self.app.frames(), Iterable)
+        self.assertIsInstance(self.app.frames(), collections.abc.Iterable)
 
     def test_broadcast(self):
         self.app.broadcastRequested = mock.MagicMock()

--- a/test.py
+++ b/test.py
@@ -169,13 +169,10 @@ class SwiftTest(unittest.TestCase):
             mocked_signal.emit.assert_called_once_with(msg, result_string)
 
     def test_swiftcall_primitive(self):
-        """The swiftcall returns a primitive type value, which can be JSONified.
-        
-        This assumes that swift.dumps() works correctly.
-        """
+        """The swiftcall returns a primitive type value, which can be JSONified."""
         value = [1.5, True, None, "abc"]
-        result = swift.SwiftcallResult(done=True, success=True, value=value)
-        self.help_swiftcall(value, result)
+        result_string = json.dumps({"done": True, "success": True, "value": value})
+        self.help_swiftcall(value, result_string)
 
     def test_swiftcall_serializable(self):
         """The swiftcall returns a Serializable type value.

--- a/test.py
+++ b/test.py
@@ -153,7 +153,14 @@ class SwiftTest(unittest.TestCase):
         value: Any,
         result: swift.SwiftcallResult,
         error: Optional[Exception] = None):
-        """Helper method for testing _swiftcall()."""
+        """Helper method for testing _swiftcall().
+        
+        Args:
+            value: The actual return value of the swift-call.
+            result: The result object that should be generated after the swift-call.
+            error: The Exception instance that should have occurred during the swift-call.
+              None if no exception is expected.
+        """
         msg = swift.dumps(swift.SwiftcallInfo(call="callForTest", args={}))
         with mock.patch.multiple(self.swift, _handleSwiftcall=mock.DEFAULT, _apps=mock.DEFAULT):
             if error is None:

--- a/test.py
+++ b/test.py
@@ -152,6 +152,19 @@ class SwiftTestWithApps(unittest.TestCase):
         self.assertNotIn("app1", self.swift._subscribers["ch1"])
         self.assertEqual(self.swift.unsubscribe("app2", "ch1"), False)
 
+    def test_broadcast(self):
+        for channelName in self.channels:
+            self.swift._broadcast(channelName, "test_msg")
+        for name, app_ in self.swift._apps.items():
+            self.assertEqual(len(APP_INFOS[name].channel), app_.received.emit.call_count)
+
+
+class SwiftTestWithoutApps(unittest.TestCase):
+    """Unit test for Swift class without apps."""
+
+    def setUp(self):
+        self.swift = swift.Swift()
+
     def help_swiftcall(self, value: Any, result_string: str, error: Optional[Exception] = None):
         """Helper method for testing _swiftcall().
         
@@ -220,12 +233,6 @@ class SwiftTestWithApps(unittest.TestCase):
             "error": repr(error),
         })
         self.help_swiftcall(None, result_string, error)
-
-    def test_broadcast(self):
-        for channelName in self.channels:
-            self.swift._broadcast(channelName, "test_msg")
-        for name, app_ in self.swift._apps.items():
-            self.assertEqual(len(APP_INFOS[name].channel), app_.received.emit.call_count)
 
     def test_parse_args_primitive(self):
         def call_for_test(number: float, boolean: bool, string: str):  # pylint: disable=unused-argument

--- a/test.py
+++ b/test.py
@@ -4,7 +4,6 @@ Module for testing swift module.
 
 import dataclasses
 import sys
-import importlib
 import json
 import unittest
 from unittest import mock

--- a/test.py
+++ b/test.py
@@ -243,7 +243,6 @@ class HandleSwiftcallTest(unittest.TestCase):
     """Unit test for Swift._handleSwiftcall()."""
 
     def setUp(self):
-        self.qapp = QApplication([])
         self.swift = swift.Swift()
         self.args = {
             "a": 1.5,

--- a/test.py
+++ b/test.py
@@ -451,7 +451,7 @@ class SwiftFunctionTest(unittest.TestCase):
 
     @mock.patch("builtins.open")
     @mock.patch("json.load", return_value={"app": APP_DICTS})
-    def test_read_setup_file(self, mock_open, mock_load):
+    def test_read_setup_file(self, mock_load, mock_open):
         self.assertEqual(swift._read_setup_file(""), APP_INFOS)
         mock_open.assert_called_once()
         mock_load.assert_called_once()

--- a/test.py
+++ b/test.py
@@ -199,12 +199,10 @@ class SwiftTest(unittest.TestCase):
             "field_null": None,
             "field_string": "",
         }
-        arg1 = ClassForTest(**fields1)
-        arg2 = ClassForTest(**fields2)
-        args = {"arg1": arg1, "arg2": arg2}
-        parsed_args = self.swift._parseArgs(call_for_test, args)
-        self.assertEqual(json.dumps(fields1), parsed_args["arg1"])
-        self.assertEqual(json.dumps(fields2), parsed_args["arg2"])
+        args = {"arg1": ClassForTest(**fields1), "arg2": ClassForTest(**fields2)}
+        json_args = {"arg1": json.dumps(fields1), "arg2": json.dumps(fields2)}
+        parsed_args = self.swift._parseArgs(call_for_test, json_args)
+        self.assertEqual(args, parsed_args)
 
 
 class BaseAppTest(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -226,6 +226,10 @@ class HandleSwiftcallTest(unittest.TestCase):
     def doCleanups(self):
         swift.loads = self._stashed_swift_loads
 
+    def test_ok(self):
+        self.swift._handleSwiftcall(sender="sender", msg=self.msg)
+        self.swift.callForTest.assert_called_once_with(**self.args)
+
 
 class BaseAppTest(unittest.TestCase):
     """Unit test for BaseApp class."""

--- a/test.py
+++ b/test.py
@@ -406,6 +406,14 @@ class SwiftcallProxyTest(unittest.TestCase):
             self.assertEqual(old_result, new_result)
             self.assertFalse(self.swiftcall.results)
 
+    def test_update_result_error(self):
+        old_result = swift.SwiftcallResult(done=False, success=False)
+        new_result = swift.SwiftcallResult(done=True, success=False, error=RuntimeError("test"))
+        with patch.object(self.swiftcall, "results", {"request": old_result}):
+            self.swiftcall.update_result("request", new_result)
+            self.assertEqual(old_result, new_result)
+            self.assertFalse(self.swiftcall.results)
+
 
 class SwiftFunctionTest(unittest.TestCase):
     """Unit test for functions."""

--- a/test.py
+++ b/test.py
@@ -76,7 +76,7 @@ class SwiftTestWithApps(unittest.TestCase):
         for appInfo in APP_INFOS.values():
             self.channels.update(appInfo.channel)
         self.swift = swift.Swift(APP_INFOS)
-    
+
     def doCleanups(self):
         self.import_module_patcher.stop()
 

--- a/test.py
+++ b/test.py
@@ -149,7 +149,7 @@ class SwiftTest(unittest.TestCase):
     def test_swiftcall_primitive(self):
         """The swiftcall returns a primitive type value, which can be JSONified.
         
-        This assumes that swift.dumps() works correctly since it is quite simple.
+        This assumes that swift.dumps() works correctly.
         """
         msg = swift.dumps(swift.SwiftcallInfo(call="callForTest", args={}))
         value = [1.5, True, None, "abc"]

--- a/test.py
+++ b/test.py
@@ -148,20 +148,17 @@ class SwiftTest(unittest.TestCase):
         self.assertNotIn("app1", self.swift._subscribers["ch1"])
         self.assertEqual(self.swift.unsubscribe("app2", "ch1"), False)
 
-    def help_swiftcall(
-        self,
-        value: Any,
-        result: swift.SwiftcallResult,
-        error: Optional[Exception] = None):
+    def help_swiftcall(self, value: Any, result_string: str, error: Optional[Exception] = None):
         """Helper method for testing _swiftcall().
         
         Args:
             value: The actual return value of the swift-call.
-            result: The result object that should be generated after the swift-call.
+            result_string: The swift.dumps()-ed string of the result object that should be
+              generated after the swift-call.
             error: The Exception instance that should have occurred during the swift-call.
               None if no exception is expected.
         """
-        msg = swift.dumps(swift.SwiftcallInfo(call="callForTest", args={}))
+        msg = json.dumps({"call": "callForTest", "args": {}})
         with mock.patch.multiple(self.swift, _handleSwiftcall=mock.DEFAULT, _apps=mock.DEFAULT):
             if error is None:
                 self.swift._handleSwiftcall.return_value = value
@@ -169,7 +166,7 @@ class SwiftTest(unittest.TestCase):
                 self.swift._handleSwiftcall.side_effect = error
             self.swift._swiftcall(sender="sender", msg=msg)
             mocked_signal = self.swift._apps["sender"].swiftcallReturned
-            mocked_signal.emit.assert_called_once_with(msg, swift.dumps(result))
+            mocked_signal.emit.assert_called_once_with(msg, result_string)
 
     def test_swiftcall_primitive(self):
         """The swiftcall returns a primitive type value, which can be JSONified.

--- a/test.py
+++ b/test.py
@@ -413,13 +413,15 @@ class SwiftcallProxyTest(unittest.TestCase):
         """Tests a duplicate proxied swiftcall.
         
         The new one should be accepted and the previous one should be discarded.
-        This assuems that swift.dumps() works correctly.
         """
         args = {"a": 123}
         msg = json.dumps({"call": "callForTest", "args": args})
         with mock.patch.object(self.swiftcall, "results", {}):
-            result1 = self.swiftcall.callForTest(**args)
-            result2 = self.swiftcall.callForTest(**args)
+            with mock.patch("swift.dumps") as mocked_dumps:
+                mocked_dumps.side_effect = (msg, msg)
+                result1 = self.swiftcall.callForTest(**args)
+                result2 = self.swiftcall.callForTest(**args)
+                self.assertEqual(len(mocked_dumps.mock_calls), 2)
             self.assertSequenceEqual(
                 self.swiftcall.requested.emit.mock_calls,
                 (mock.call(msg), mock.call(msg)),

--- a/test.py
+++ b/test.py
@@ -207,11 +207,15 @@ class SwiftTestWithApps(unittest.TestCase):
     def test_swiftcall_exception(self):
         """The swiftcall raises an exception."""
         class ExceptionForTest(Exception):
-            ...
-        value = None
+            """Temporary exception only for this test."""
         error = ExceptionForTest("test")
-        result = swift.SwiftcallResult(done=True, success=False, error=repr(error))
-        self.help_swiftcall(value, result, error)
+        result_string = json.dumps({
+            "done": True,
+            "success": False,
+            "value": None,
+            "error": repr(error),
+        })
+        self.help_swiftcall(None, result_string, error)
 
     def test_broadcast(self):
         for channelName in self.channels:

--- a/test.py
+++ b/test.py
@@ -398,16 +398,13 @@ class SwiftcallProxyTest(unittest.TestCase):
             self.assertEqual(result2, swift.SwiftcallResult(done=False, success=False))
             self.assertEqual(result1, result2)
 
-    def test_update_result(self):
-        self.swiftcall.results = {
-            "request1": swift.SwiftcallResult(done=False, success=False), "request2": None
-        }
-        self.swiftcall.update_result(
-            "request1", swift.SwiftcallResult(done=True, success=True), discard=False
-        )
-        self.swiftcall.update_result(
-            "request2", swift.SwiftcallResult(done=True, success=True)
-        )
+    def test_update_result_success(self):
+        old_result = swift.SwiftcallResult(done=False, success=False)
+        new_result = swift.SwiftcallResult(done=True, success=True, value=0)
+        with patch.object(self.swiftcall, "results", {"request": old_result}):
+            self.swiftcall.update_result("request", new_result)
+            self.assertEqual(old_result, new_result)
+            self.assertFalse(self.swiftcall.results)
 
 
 class SwiftFunctionTest(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -171,7 +171,7 @@ class SwiftTest(unittest.TestCase):
     def test_swiftcall_primitive(self):
         """The swiftcall returns a primitive type value, which can be JSONified."""
         value = [1.5, True, None, "abc"]
-        result_string = json.dumps({"done": True, "success": True, "value": value})
+        result_string = json.dumps({"done": True, "success": True, "value": value, "error": None})
         self.help_swiftcall(value, result_string)
 
     def test_swiftcall_serializable(self):
@@ -183,8 +183,15 @@ class SwiftTest(unittest.TestCase):
         class ClassForTest(swift.Serializable):
             a: str
         value = ClassForTest(a="abc")
-        result = swift.SwiftcallResult(done=True, success=True, value=swift.dumps(value))
-        self.help_swiftcall(value, result)
+        value_string = json.dumps({"a": "abc"})
+        result = swift.SwiftcallResult(done=True, success=True, value=value_string)
+        result_string = json.dumps({"done": True, "success": True, "value": value_string})
+        string_map = {
+            value: value_string,
+            result: result_string,
+        }
+        with mock.patch("swift.dumps", mock.MagicMock(side_effect=string_map.get)):
+            self.help_swiftcall(value, result_string)
 
     def test_swiftcall_exception(self):
         """The swiftcall raises an exception."""

--- a/test.py
+++ b/test.py
@@ -9,7 +9,7 @@ import json
 import unittest
 from unittest.mock import MagicMock, patch
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, Optional
 
 from PyQt5.QtCore import QObject
 from PyQt5.QtWidgets import QApplication, QMessageBox, QWidget
@@ -146,12 +146,19 @@ class SwiftTest(unittest.TestCase):
         self.assertNotIn("app1", self.swift._subscribers["ch1"])
         self.assertEqual(self.swift.unsubscribe("app2", "ch1"), False)
 
-    def help_swiftcall(self, value, result):
+    def help_swiftcall(
+        self,
+        value: Any,
+        result: swift.SwiftcallResult,
+        error: Optional[Exception] = None):
         """Helper method for testing _swiftcall()."""
         msg = swift.dumps(swift.SwiftcallInfo(call="callForTest", args={}))
-        self.swift._handleSwiftcall = MagicMock(return_value=value)
         signal = MagicMock()
         self.swift._apps["app1"].swiftcallReturned = signal
+        if error is None:
+            self.swift._handleSwiftcall = MagicMock(return_value=value)
+        else:
+            self.swift._handleSwiftcall = MagicMock(side_effect=error)
         self.swift._swiftcall(sender="app1", msg=msg)
         signal.emit.assert_called_once_with(msg, swift.dumps(result))
 

--- a/test.py
+++ b/test.py
@@ -236,6 +236,14 @@ class HandleSwiftcallTest(unittest.TestCase):
             self.swift._handleSwiftcall(sender="sender", msg=self.msg)
         self.swift.callForTest.assert_not_called()
 
+    def test_non_public(self):
+        self.call.call = "_callForTest"
+        self.msg = json.dumps(dataclasses.asdict(self.call))
+        self.swift._callForTest = MagicMock()
+        with self.assertRaises(ValueError):
+            self.swift._handleSwiftcall(sender="sender", msg=self.msg)
+        self.swift._callForTest.assert_not_called()
+
 
 class BaseAppTest(unittest.TestCase):
     """Unit test for BaseApp class."""

--- a/test.py
+++ b/test.py
@@ -337,10 +337,19 @@ class SwiftcallProxyTest(unittest.TestCase):
     def setUp(self):
         self.swiftcall = swift.SwiftcallProxy(MagicMock())
 
-    def test_getattr(self):
-        self.swiftcall.call()
-        self.swiftcall.call(name=APP_INFOS["app1"])
-        self.swiftcall.call()
+    def test_proxy_primitive(self):
+        """Tests a proxied swiftcall with primitive type arguments.
+        
+        This assumes that swift.dumps() works correctly.
+        """
+        args = {"number": 1.5, "boolean": True, "string": "abc"}
+        info = swift.SwiftcallInfo(call="callForTest", args=args)
+        msg = swift.dumps(info)
+        with patch.object(self.swiftcall, "results", {}):
+            result = self.swiftcall.callForTest(**args)
+            self.swiftcall.requested.emit.assert_called_once_with(msg)
+            self.assertIs(result, self.swiftcall.results[msg])
+            self.assertEqual(result, swift.SwiftcallResult(done=False, success=False))
 
     def test_update_result(self):
         self.swiftcall.results = {

--- a/test.py
+++ b/test.py
@@ -394,13 +394,13 @@ class SwiftFunctionTest(unittest.TestCase):
     @patch("swift._get_argparser")
     @patch("swift._read_setup_file", return_value={})
     @patch("swift.Swift")
-    @patch("PyQt5.QtWidgets.QApplication.exec_")
-    def test_main(self, mock_get_argparser, mock_read_setup_file, mock_swift, mock_exec_):
+    @patch("swift.QApplication")
+    def test_main(self, mock_qapp, mock_swift, mock_read_setup_file, mock_get_argparser):
         swift.main()
         mock_get_argparser.assert_called_once()
         mock_read_setup_file.assert_called_once()
         mock_swift.assert_called_once()
-        mock_exec_.assert_called_once()
+        mock_qapp.return_value.exec_.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -414,6 +414,14 @@ class SwiftcallProxyTest(unittest.TestCase):
             self.assertEqual(old_result, new_result)
             self.assertFalse(self.swiftcall.results)
 
+    def test_update_result_no_discard(self):
+        old_result = swift.SwiftcallResult(done=False, success=False)
+        new_result = swift.SwiftcallResult(done=True, success=True, value=0)
+        with patch.object(self.swiftcall, "results", {"request": old_result}):
+            self.swiftcall.update_result("request", new_result, discard=False)
+            self.assertEqual(old_result, new_result)
+            self.assertIs(old_result, self.swiftcall.results["request"])
+
 
 class SwiftFunctionTest(unittest.TestCase):
     """Unit test for functions."""

--- a/test.py
+++ b/test.py
@@ -285,6 +285,8 @@ class HandleSwiftcallTest(unittest.TestCase):
             self.swift._handleSwiftcall(sender="sender", msg=msg)
             self.swift.callForTest.assert_called_once_with(**args)
             self.swift._parseArgs.assert_called_once_with(self.swift.callForTest, args)
+        mocked_loads.assert_called_once()
+        mocked_warning.assert_called_once()
 
     def test_cancel(self, mocked_warning, mocked_loads):
         args = {"a": 123, "b": "ABC"}
@@ -299,6 +301,8 @@ class HandleSwiftcallTest(unittest.TestCase):
                 self.swift._handleSwiftcall(sender="sender", msg=msg)
             self.swift.callForTest.assert_not_called()
             self.swift._parseArgs.assert_called_once_with(self.swift.callForTest, args)
+        mocked_loads.assert_called_once()
+        mocked_warning.assert_called_once()
 
     def test_non_public(self, mocked_warning, mocked_loads):
         args = {"a": 123, "b": "ABC"}

--- a/test.py
+++ b/test.py
@@ -478,6 +478,13 @@ class SwiftcallProxyTest(unittest.TestCase):
             self.assertEqual(old_result, new_result)
             self.assertIs(old_result, self.swiftcall.results["request"])
 
+    def test_update_result_not_exist(self):
+        """When the request is not in the results dictionary, it is ignored."""
+        new_result = swift.SwiftcallResult(done=True, success=True, value=0)
+        with mock.patch.object(self.swiftcall, "results", {}):
+            self.swiftcall.update_result("request", new_result)
+            self.assertNotIn("request", self.swiftcall.results)
+
 
 class SwiftFunctionTest(unittest.TestCase):
     """Unit test for functions."""

--- a/test.py
+++ b/test.py
@@ -190,8 +190,8 @@ class SwiftTestWithoutApps(unittest.TestCase):
         value = [1.5, True, None, "abc"]
         result_string = json.dumps({"done": True, "success": True, "value": value, "error": None})
         with mock.patch("swift.dumps") as mocked_dumps:
+            mocked_dumps.side_effect = (result_string,)
             self.help_swiftcall(value, result_string)
-            mocked_dumps.assert_not_called()
 
     def test_swiftcall_serializable(self):
         """The swiftcall returns a Serializable type value."""

--- a/test.py
+++ b/test.py
@@ -304,6 +304,11 @@ class HandleSwiftcallTest(unittest.TestCase):
             self.swift._handleSwiftcall(sender="sender", msg=self.msg)
         self.swift._callForTest.assert_not_called()
 
+    @unittest.expectedFailure
+    def test_not_existing_method(self):
+        del self.swift.callForTest
+        self.swift._handleSwiftcall(sender="sender", msg=self.msg)
+
 
 class BaseAppTest(unittest.TestCase):
     """Unit test for BaseApp class."""

--- a/test.py
+++ b/test.py
@@ -318,10 +318,17 @@ class HandleSwiftcallTest(unittest.TestCase):
         mocked_loads.assert_called_once()
         mocked_warning.assert_not_called()
 
-    @unittest.expectedFailure
-    def test_not_existing_method(self):
-        del self.swift.callForTest
-        self.swift._handleSwiftcall(sender="sender", msg=self.msg)
+    def test_not_existing_method(self, mocked_warning, mocked_loads):
+        args = {"a": 123, "b": "ABC"}
+        info = swift.SwiftcallInfo(call="callForTest", args=args)
+        msg = json.dumps({"call": "callForTest", "args": args})
+        mocked_loads.return_value = info
+        with mock.patch.multiple(self.swift, create=True, _parseArgs=mock.DEFAULT):
+            with self.assertRaises(AttributeError):
+                self.swift._handleSwiftcall(sender="sender", msg=msg)
+            self.swift._parseArgs.assert_not_called()
+        mocked_loads.assert_called_once()
+        mocked_warning.assert_not_called()
 
 
 class BaseAppTest(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -60,8 +60,8 @@ APP_JSONS = {
 qapp = QApplication(sys.argv)
 
 
-class SwiftTest(unittest.TestCase):
-    """Unit test for Swift class."""
+class SwiftTestWithApps(unittest.TestCase):
+    """Unit test for Swift class with creating apps."""
 
     def setUp(self):
         importlib.import_module = mock.MagicMock()

--- a/test.py
+++ b/test.py
@@ -202,36 +202,32 @@ class SwiftTest(unittest.TestCase):
 
     def test_parse_args_primitive(self):
         def call_for_test(
-            arg_number: float,
-            arg_bool: bool,
-            arg_null: Any,
-            arg_string: str
+            number: float,
+            boolean: bool,
+            string: str
         ):  # pylint: disable=unused-argument
             """A dummy function for testing, which has only primitive type arguments."""
-        args = {"arg_number": 1.5, "arg_bool": True, "arg_null": None, "arg_string": "abc"}
+        args = {"number": 1.5, "boolean": True, "string": "abc"}
         parsed_args = self.swift._parseArgs(call_for_test, args)
         self.assertEqual(args, parsed_args)
 
     def test_parse_args_serializable(self):
         @dataclasses.dataclass
         class ClassForTest(swift.Serializable):
-            field_number: float
-            field_bool: bool
-            field_null: None
-            field_string: str
+            number: float
+            boolean: bool
+            string: str
         def call_for_test(arg1: ClassForTest, arg2: ClassForTest):  # pylint: disable=unused-argument
             """A dummy function for testing, which has only Serializable type arguments."""
         fields1 = {
-            "field_number": 1.5,
-            "field_bool": True,
-            "field_null": None,
-            "field_string": "abc",
+            "number": 1.5,
+            "boolean": True,
+            "string": "abc",
         }
         fields2 = {
-            "field_number": 0,
-            "field_bool": False,
-            "field_null": None,
-            "field_string": "",
+            "number": 0,
+            "boolean": False,
+            "string": "",
         }
         args = {"arg1": ClassForTest(**fields1), "arg2": ClassForTest(**fields2)}
         json_args = {"arg1": json.dumps(fields1), "arg2": json.dumps(fields2)}

--- a/test.py
+++ b/test.py
@@ -183,6 +183,15 @@ class SwiftTest(unittest.TestCase):
         result = swift.SwiftcallResult(done=True, success=True, value=swift.dumps(value))
         self.help_swiftcall(value, result)
 
+    def test_swiftcall_exception(self):
+        """The swiftcall raises an exception."""
+        class ExceptionForTest(Exception):
+            ...
+        value = None
+        error = ExceptionForTest("test")
+        result = swift.SwiftcallResult(done=True, success=False, error=repr(error))
+        self.help_swiftcall(value, result, error)
+
     def test_broadcast(self):
         for channelName in self.channels:
             self.swift._broadcast(channelName, "test_msg")

--- a/test.py
+++ b/test.py
@@ -9,6 +9,7 @@ import json
 import unittest
 from unittest.mock import MagicMock, patch
 from collections.abc import Iterable
+from typing import Any
 
 from PyQt5.QtCore import QObject
 from PyQt5.QtWidgets import QApplication, QMessageBox, QWidget
@@ -166,7 +167,12 @@ class SwiftTest(unittest.TestCase):
             self.assertEqual(len(APP_INFOS[name].channel), app_.received.emit.call_count)
 
     def test_parse_args_primitive(self):
-        def call_for_test(arg_number: float, arg_bool: bool, arg_null: None, arg_string: str):  # pylint: disable=unused-argument
+        def call_for_test(
+            arg_number: float,
+            arg_bool: bool,
+            arg_null: Any,
+            arg_string: str
+        ):  # pylint: disable=unused-argument
             """A dummy function for testing, which has only primitive type arguments."""
         args = {"arg_number": 1.5, "arg_bool": True, "arg_null": None, "arg_string": "abc"}
         parsed_args = self.swift._parseArgs(call_for_test, args)

--- a/test.py
+++ b/test.py
@@ -166,7 +166,7 @@ class SwiftTest(unittest.TestCase):
             self.assertEqual(len(APP_INFOS[name].channel), app_.received.emit.call_count)
 
     def test_parse_args_primitive(self):
-        def call_for_test(arg_number: float, arg_bool: bool, arg_null: None, arg_string: str):
+        def call_for_test(arg_number: float, arg_bool: bool, arg_null: None, arg_string: str):  # pylint: disable=unused-argument
             """A dummy function for testing, which has only primitive type arguments."""
         args = {"arg_number": 1.5, "arg_bool": True, "arg_null": None, "arg_string": "abc"}
         parsed_args = self.swift._parseArgs(call_for_test, args)
@@ -179,7 +179,7 @@ class SwiftTest(unittest.TestCase):
             field_bool: bool
             field_null: None
             field_string: str
-        def call_for_test(arg1: ClassForTest, arg2: ClassForTest):
+        def call_for_test(arg1: ClassForTest, arg2: ClassForTest):  # pylint: disable=unused-argument
             """A dummy function for testing, which has only Serializable type arguments."""
         fields1 = {
             "field_number": 1.5,

--- a/test.py
+++ b/test.py
@@ -164,6 +164,13 @@ class SwiftTest(unittest.TestCase):
         for name, app_ in self.swift._apps.items():
             self.assertEqual(len(APP_INFOS[name].channel), app_.received.emit.call_count)
 
+    def test_parse_args_primitive(self):
+        def call_for_test(arg_number: float, arg_bool: bool, arg_null: None, arg_string: str):
+            """A dummy function for testing, which has only primitive type arguments."""
+        args = {"arg_number": 1.5, "arg_bool": True, "arg_null": None, "arg_string": "abc"}
+        parsed_args = self.swift._parseArgs(call_for_test, args)
+        self.assertEqual(args, parsed_args)
+
 
 class BaseAppTest(unittest.TestCase):
     """Unit test for BaseApp class."""

--- a/test.py
+++ b/test.py
@@ -57,11 +57,13 @@ APP_JSONS = {
 }
 
 
+qapp = QApplication(sys.argv)
+
+
 class SwiftTest(unittest.TestCase):
     """Unit test for Swift class."""
 
     def setUp(self):
-        self.qapp = QApplication(sys.argv)
         importlib.import_module = MagicMock()
         for appInfo in APP_INFOS.values():
             app_ = MagicMock()

--- a/test.py
+++ b/test.py
@@ -205,6 +205,28 @@ class SwiftTest(unittest.TestCase):
         self.assertEqual(args, parsed_args)
 
 
+class HandleSwiftcallTest(unittest.TestCase):
+    """Unit test for Swift._handleSwiftcall()."""
+
+    def setUp(self):
+        self.qapp = QApplication([])
+        self.swift = swift.Swift()
+        self.args = {
+            "a": 1.5,
+            "b": None,
+        }
+        self.call = swift.SwiftcallInfo(call="callForTest", args=self.args)
+        self.msg = json.dumps(dataclasses.asdict(self.call))
+        self.swift.callForTest = MagicMock()
+        self.swift._parseArgs = MagicMock(return_value=self.args)
+        QMessageBox.warning = MagicMock(return_value=QMessageBox.Ok)
+        self._stashed_swift_loads = swift.loads
+        swift.loads = MagicMock(return_value=self.call)
+
+    def doCleanups(self):
+        swift.loads = self._stashed_swift_loads
+
+
 class BaseAppTest(unittest.TestCase):
     """Unit test for BaseApp class."""
 

--- a/test.py
+++ b/test.py
@@ -230,6 +230,12 @@ class HandleSwiftcallTest(unittest.TestCase):
         self.swift._handleSwiftcall(sender="sender", msg=self.msg)
         self.swift.callForTest.assert_called_once_with(**self.args)
 
+    def test_cancel(self):
+        QMessageBox.warning.return_value = QMessageBox.Cancel
+        with self.assertRaises(RuntimeError):
+            self.swift._handleSwiftcall(sender="sender", msg=self.msg)
+        self.swift.callForTest.assert_not_called()
+
 
 class BaseAppTest(unittest.TestCase):
     """Unit test for BaseApp class."""

--- a/test.py
+++ b/test.py
@@ -210,7 +210,6 @@ class SwiftTestWithoutApps(unittest.TestCase):
             a: str
         value = ClassForTest(a="abc")
         value_string = json.dumps({"a": "abc"})
-        result = swift.SwiftcallResult(done=True, success=True, value=value_string)
         result_string = json.dumps({
             "done": True,
             "success": True,

--- a/test.py
+++ b/test.py
@@ -172,7 +172,9 @@ class SwiftTest(unittest.TestCase):
         """The swiftcall returns a primitive type value, which can be JSONified."""
         value = [1.5, True, None, "abc"]
         result_string = json.dumps({"done": True, "success": True, "value": value, "error": None})
-        self.help_swiftcall(value, result_string)
+        with mock.patch("swift.dumps") as mocked_dumps:
+            self.help_swiftcall(value, result_string)
+            mocked_dumps.assert_not_called()
 
     def test_swiftcall_serializable(self):
         """The swiftcall returns a Serializable type value."""


### PR DESCRIPTION
As I talked with @BECATRUE off-line, we found some bugs in the test codes.

- `patch()` decorators give the arguments in a reversed order.
- Patch target description should be `swift.QApplication` to mock `QApplication` in `swift.main()`.
- `QApplication` should be instantiated outside (globally) once.

This closes #162.