### PR TITLE
Change `swift` to `qiwi`

### DIFF
--- a/.pylintrc_test
+++ b/.pylintrc_test
@@ -16,4 +16,4 @@ disable=
     protected-access,
 
 [TYPECHECK]
-ignored-modules=swift
+ignored-modules=qiwi

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 [![unittest](https://github.com/snu-quiqcl/qiwi/actions/workflows/unittest.yml/badge.svg)](https://github.com/snu-quiqcl/qiwi/actions/workflows/unittest.yml)
 
-# QIWI
-QIWI (**S**NU **w**idget **i**ntegration **f**ramework for PyQ**t**) is a framework for integration of PyQt widgets where they can communicate with each other. This project is mainly developed for trapped ion experiment controller GUI in SNU QuIQCL.
+# qiwi
+QIWI (**Q**u**I**qcl **W**idget **I**ntegration framework) is a framework for integration of PyQt widgets where they can communicate with each other. This project is mainly developed for trapped ion experiment controller GUI in SNU QuIQCL.
 
 ## How to download and install
 One of the below:
 - Using released version (_recommended_)
-1. `pip install git_https://github.com/snu-quiqcl/qiwi.git@v1.0.1`
+1. `pip install git_https://github.com/snu-quiqcl/qiwi.git@v2.0.0`
 
 - Using git directly
 1. `git clone ${url}`: The default branch is `develop`, not `main`. There is no guarantee for stability.

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
   <img width="40%" alt="image" src="https://user-images.githubusercontent.com/65724072/235589514-ed021c0c-cf20-4ba1-b8af-3b1d0da65362.svg">
 </p>
 
-[![Pylint](https://github.com/snu-quiqcl/swift/actions/workflows/pylint.yml/badge.svg)](https://github.com/snu-quiqcl/swift/actions/workflows/pylint.yml)
+[![Pylint](https://github.com/snu-quiqcl/qiwi/actions/workflows/pylint.yml/badge.svg)](https://github.com/snu-quiqcl/qiwi/actions/workflows/pylint.yml)
 
-[![unittest](https://github.com/snu-quiqcl/swift/actions/workflows/unittest.yml/badge.svg)](https://github.com/snu-quiqcl/swift/actions/workflows/unittest.yml)
+[![unittest](https://github.com/snu-quiqcl/qiwi/actions/workflows/unittest.yml/badge.svg)](https://github.com/snu-quiqcl/qiwi/actions/workflows/unittest.yml)
 
-# swift
-Swift (**S**NU **w**idget **i**ntegration **f**ramework for PyQ**t**) is a framework for integration of PyQt widgets where they can communicate with each other. This project is mainly developed for trapped ion experiment controller GUI in SNU QuIQCL.
+# QIWI
+QIWI (**S**NU **w**idget **i**ntegration **f**ramework for PyQ**t**) is a framework for integration of PyQt widgets where they can communicate with each other. This project is mainly developed for trapped ion experiment controller GUI in SNU QuIQCL.
 
 ## How to download and install
 One of the below:
 - Using released version (_recommended_)
-1. `pip install git_https://github.com/snu-quiqcl/swift.git@v1.0.1`
+1. `pip install git_https://github.com/snu-quiqcl/qiwi.git@v1.0.1`
 
 - Using git directly
 1. `git clone ${url}`: The default branch is `develop`, not `main`. There is no guarantee for stability.
@@ -21,4 +21,4 @@ One of the below:
 ## How to use
 In the repository, just do like as below:
 
-`python -m swift.swift (-s ${setup_file))`.
+`python -m qiwi (-s ${setup_file))`.

--- a/examples/datacalc.py
+++ b/examples/datacalc.py
@@ -9,7 +9,7 @@ from typing import Any, Optional, Dict, Tuple
 from PyQt5.QtCore import QObject, pyqtSlot
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QComboBox, QPushButton, QLabel
 
-from swift import BaseApp
+from qiwi import BaseApp
 from examples.backend import read
 
 class ViewerFrame(QWidget):

--- a/examples/dbmgr.py
+++ b/examples/dbmgr.py
@@ -10,7 +10,7 @@ from PyQt5.QtCore import QObject, pyqtSlot
 from PyQt5.QtWidgets import (QWidget, QLabel, QPushButton, QFileDialog,
                              QHBoxLayout, QVBoxLayout, QListWidget, QListWidgetItem)
 
-from swift import AppInfo, BaseApp
+from qiwi import AppInfo, BaseApp
 
 class DBWidget(QWidget):
     """Widget for showing a database.
@@ -91,7 +91,7 @@ class DBMgrApp(BaseApp):
           Each element is a namedtuple which represents a database.
           It has two elements; file name and absolute path.
         isDatacalcOpen: True if a datacalc app is open, and False if it is close.
-        openCloseDatacalcResult: The latest swiftcall result 
+        openCloseDatacalcResult: The latest qiwicall result 
           which requests for opening or closing a datacalc app.
         managerFrame: A frame that manages and shows available databases.
     """
@@ -181,14 +181,14 @@ class DBMgrApp(BaseApp):
         """
         if self.openCloseDatacalcResult is not None:
             if not self.openCloseDatacalcResult.done:
-                print("DBMgrApp.openCloseDatacalc(): The previous swiftcall must be done.")
+                print("DBMgrApp.openCloseDatacalc(): The previous qiwicall must be done.")
                 return
             if self.openCloseDatacalcResult.success:
                 self.isDatacalcOpen = not self.isDatacalcOpen
         if self.isDatacalcOpen:
-            self.openCloseDatacalcResult = self.swiftcall.destroyApp(name="datacalc")
+            self.openCloseDatacalcResult = self.qiwicall.destroyApp(name="datacalc")
         else:
-            self.openCloseDatacalcResult = self.swiftcall.createApp(
+            self.openCloseDatacalcResult = self.qiwicall.createApp(
                 name="datacalc",
                 info=AppInfo(
                     module="examples.datacalc",

--- a/examples/logger.py
+++ b/examples/logger.py
@@ -8,7 +8,7 @@ from typing import Any, Optional, Tuple
 from PyQt5.QtCore import QObject, pyqtSlot, pyqtSignal
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QPushButton, QTextEdit, QLabel, QDialogButtonBox
 
-from swift import BaseApp
+from qiwi import BaseApp
 
 class LoggerFrame(QWidget):
     """Frame for logging.

--- a/examples/numgen.py
+++ b/examples/numgen.py
@@ -10,7 +10,7 @@ from typing import Any, Optional, Tuple, Union
 from PyQt5.QtCore import QObject, pyqtSlot
 from PyQt5.QtWidgets import QWidget, QComboBox, QPushButton, QLabel, QVBoxLayout
 
-from swift import BaseApp
+from qiwi import BaseApp
 from examples.backend import generate, write
 
 class GeneratorFrame(QWidget):
@@ -161,7 +161,7 @@ class NumGenApp(BaseApp):
         num = generate()
         if not self.isGenerated:
             self.isGenerated = True
-            self.swiftcall.updateFrames(name=self.name)
+            self.qiwicall.updateFrames(name=self.name)
         self.viewerFrame.numberLabel.setText(f"generated number: {num}")
         self.broadcast("log", f"Generated number: {num}.")
         # save the generated number

--- a/examples/poller.py
+++ b/examples/poller.py
@@ -8,7 +8,7 @@ from typing import Any, Optional, Tuple
 from PyQt5.QtCore import QObject, pyqtSlot, QTimer
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QComboBox, QSpinBox, QLabel
 
-from swift import BaseApp
+from qiwi import BaseApp
 from examples.backend import poll, write
 
 class ViewerFrame(QWidget):

--- a/qiwi.py
+++ b/qiwi.py
@@ -37,7 +37,7 @@ class Serializable:  # pylint: disable=too-few-public-methods
     The message protocols in qiwi use JSON strings to encode data.
     If a dataclass inherits this class, the dictionary yielded by asdict() must
       be able to converted to a JSON string, i.e., JSONifiable.
-    Every argument of qiwi-calls must be JSONifiable by itself
+    Every argument of qiwicalls must be JSONifiable by itself
       or an instance of Serializable.
     """
 
@@ -93,12 +93,12 @@ def dumps(obj: Serializable) -> str:
 
 @dataclasses.dataclass
 class QiwicallInfo(Serializable):
-    """Information of a qiwi-call request.
+    """Information of a qiwicall request.
     
     Fields:
-        call: The name of the qiwi-call feature, e.g., "createApp" for createApp().
+        call: The name of the qiwicall feature, e.g., "createApp" for createApp().
           This is case-sensitive.
-        args: The arguments of the qiwi-call as a dictionary of keyword arguements.
+        args: The arguments of the qiwicall as a dictionary of keyword arguements.
           The names of the arguements are case-sensitive.
           When an argument is Serializable, it must be given as a converted JSON string,
           e.g., not {"arg": QiwicallInfo(call="call")},
@@ -110,13 +110,13 @@ class QiwicallInfo(Serializable):
 
 @dataclasses.dataclass
 class QiwicallResult(Serializable):
-    """Result data of a qiwi-call.
+    """Result data of a qiwicall.
     
     Fields:
-        done: Whether the qiwi-call is done. Even when it failed, this is True as well.
-        success: True when the qiwi-call is done without any problems.
-        value: Return value of the qiwi-call, if any. It must be JSONifiable.
-        error: Information about the problem that occurred during the qiwi-call.
+        done: Whether the qiwicall is done. Even when it failed, this is True as well.
+        success: True when the qiwicall is done without any problems.
+        value: Return value of the qiwicall, if any. It must be JSONifiable.
+        error: Information about the problem that occurred during the qiwicall.
     """
     done: bool
     success: bool
@@ -129,8 +129,8 @@ class Qiwi(QObject):
 
     Note that QApplication instance must be created before instantiating Qiwi object.
 
-    A qiwi-call is a request for the qiwi system such as creating an app.
-    Messages emitted from "qiwicallRequested" signal are considered as qiwi-call.
+    A qiwicall is a request for the qiwi system such as creating an app.
+    Messages emitted from "qiwicallRequested" signal are considered as qiwicall.
     For details, see _qiwicall().
 
     Brief procedure:
@@ -176,7 +176,7 @@ class Qiwi(QObject):
     def addFrame(self, name: str, frame: QWidget, info: AppInfo):
         """Adds a frame of the app and wraps it with a dock widget.
 
-        This is not a qiwi-call because QWidget is not Serializable.
+        This is not a qiwicall because QWidget is not Serializable.
         
         Args:
             name: A name of app.
@@ -198,7 +198,7 @@ class Qiwi(QObject):
     def removeFrame(self, name: str, dockWidget: QDockWidget):
         """Removes the frame from the main window.
         
-        This is not a qiwi-call because QDockWidget is not Serializable.
+        This is not a qiwicall because QDockWidget is not Serializable.
         
         Args:
             name: A name of app.
@@ -344,7 +344,7 @@ class Qiwi(QObject):
         return parsedArgs
 
     def _handleQiwicall(self, sender: str, msg: str) -> Any:
-        """Handles the qiwi-call.
+        """Handles the qiwicall.
 
         This can raise an exception if the arguments do not follow the valid API.
         The caller must obey the API and catch the possible exceptions.
@@ -362,7 +362,7 @@ class Qiwi(QObject):
             RuntimeError: When the user rejects the request.
         
         Returns:
-            The returned value of the qiwi-call, if any.
+            The returned value of the qiwicall, if any.
         """
         info = loads(QiwicallInfo, msg)
         if info.call.startswith("_"):
@@ -371,8 +371,8 @@ class Qiwi(QObject):
         args = self._parseArgs(call, info.args)
         reply = QMessageBox.warning(
             None,
-            "qiwi-call",
-            f"The app {sender} requests for a qiwi-call {info.call} with {args}.",
+            "qiwicall",
+            f"The app {sender} requests for a qiwicall {info.call} with {args}.",
             QMessageBox.Ok | QMessageBox.Cancel,
             QMessageBox.Cancel,
         )
@@ -409,15 +409,15 @@ class BaseApp(QObject):
           broadcasting to a channel with the target channel name and the message.
         received(channel, message): A broadcast message is received from a channel.
         qiwicallRequested(request): The app can emit this signal to request
-          a qiwi-call with a request message converted from a qiwi.QiwicallInfo
+          a qiwicall with a request message converted from a qiwi.QiwicallInfo
           object by qiwi.dumps().
-        qiwicallReturned(request, result): The result of the requested qiwi-call
+        qiwicallReturned(request, result): The result of the requested qiwicall
           with the original requested message and the result message converted
           from a qiwi.QiwicallResult object by qiwi.dumps().
     
     Attributes:
         name: The string identifier name of this app.
-        qiwicall: A qiwi-call proxy for requesting qiwi-calls conveniently.
+        qiwicall: A qiwicall proxy for requesting qiwicalls conveniently.
     """
 
     broadcastRequested = pyqtSignal(str, str)
@@ -492,7 +492,7 @@ class BaseApp(QObject):
         Args:
             request: The request message that has been sent via 
               self.qiwicallRequested signal.
-            msg: The received qiwi-call result message.
+            msg: The received qiwicall result message.
         """
         try:
             result = loads(QiwicallResult, msg)
@@ -503,10 +503,10 @@ class BaseApp(QObject):
 
 
 class QiwicallProxy:  # pylint: disable=too-few-public-methods
-    """A proxy for requesting qiwi-calls conveniently.
+    """A proxy for requesting qiwicalls conveniently.
     
     Every attribute access is proxied, and if you try to call a method of this
-    object, it will emit a qiwi-call requesting signal instead.
+    object, it will emit a qiwicall requesting signal instead.
     If you get an attribute of this object, you will get a callable object which
     does the same thing as calling a method of this object.
     """
@@ -521,25 +521,25 @@ class QiwicallProxy:  # pylint: disable=too-few-public-methods
         self.results: Dict[str, QiwicallResult] = {}
 
     def __getattr__(self, call: str) -> Callable:
-        """Returns a callable object which emits a qiwi-call requesting signal.
+        """Returns a callable object which emits a qiwicall requesting signal.
 
         Args:
-            call: The name of the qiwi-call.
+            call: The name of the qiwicall.
         """
         def proxy(**args: Any) -> QiwicallResult:
-            """Emits a qiwi-call request signal with the given arguments.
+            """Emits a qiwicall request signal with the given arguments.
 
             It saves the returned result to self.results dictionary, so when
-            self.returned signal is emitted, i.e., the qiwi-call result is received,
+            self.returned signal is emitted, i.e., the qiwicall result is received,
             it will update the result object contents.
 
             Args:
-                **args: The arguments for the qiwi-call, all as keyword arguments.
+                **args: The arguments for the qiwicall, all as keyword arguments.
                   If an argument is a qiwi.Serializable instance, it will be
                   converted to a JSON string by qiwi.dumps().
 
             Returns:
-                A qiwi-call result object to keep tracking the result.
+                A qiwicall result object to keep tracking the result.
             """
             for name, arg in args.items():
                 if isinstance(arg, Serializable):

--- a/qiwi.py
+++ b/qiwi.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-QIWI is a main manager for qiwi system.
+Qiwi is a main manager for qiwi system.
 
 Using a set-up file written by a user, it sets up apps.
 

--- a/qiwi.py
+++ b/qiwi.py
@@ -352,9 +352,9 @@ class Qiwi(QObject):
 
         Args:
             sender: The name of the request sender app.
-            msg: A JSON string that can be converted to SwiftcallInfo,
+            msg: A JSON string that can be converted to QiwicallInfo,
               i.e., the same form as the returned string of dumps().
-              See SwiftcallInfo for details.
+              See QiwicallInfo for details.
         
         Raises:
             ValueError: When the requested call is not public, i.e., starts with

--- a/setup.py
+++ b/setup.py
@@ -10,20 +10,20 @@ if sys.version_info[:2] < (3, 7):
     sys.exit()
 
 setup(
-    name="swift",
+    name="qiwi",
     version="2.0.0",  # indicate the following version
     author="QuIQCL",
     author_email="kangz12345@snu.ac.kr",
-    url="https://github.com/snu-quiqcl/swift",
+    url="https://github.com/snu-quiqcl/qiwi",
     description="SNU widget integration framework for PyQt",
     long_description=
         "A framework for integration of PyQt widgets where they can communicate with each other. "
         "This project is mainly developed for trapped ion experiment controller GUI in SNU QuIQCL.",
-    download_url="https://github.com/snu-quiqcl/swift/releases/tag/v2.0.0",
+    download_url="https://github.com/snu-quiqcl/qiwi/releases/tag/v2.0.0",
     license="MIT license",
     install_requires=["pyqt5"],
-    packages=find_packages(include=["swift", "swift.*"]),
+    packages=find_packages(include=["qiwi"]),
     entry_points={
-        "console_scripts": ["swift = swift.swift:main"]
+        "console_scripts": ["qiwi = qiwi:main"]
     }
 )


### PR DESCRIPTION
I just replaced `swift` to `qiwi` and rename `swift.py` to `qiwi.py`.

This PR is related to #156 and once it is approved, I will change the repository name.

<img width="50%" src="https://github.com/snu-quiqcl/swift/assets/76851886/1a609f55-9513-47b2-af63-a48cf7c789d2">
